### PR TITLE
More than one attribute on the same line

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -136,7 +136,7 @@ module AttrEncrypted
         value.respond_to?(:empty?) ? !value.empty? : !!value
       end
 
-      encrypted_attributes[attribute.to_sym] = options.merge!(:attribute => encrypted_attribute_name)
+      encrypted_attributes[attribute.to_sym] = options.merge(:attribute => encrypted_attribute_name)
     end
   end
   alias_method :attr_encryptor, :attr_encrypted

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -61,6 +61,10 @@ class AttrEncryptedTest < Test::Unit::TestCase
     assert User.attr_encrypted?('email')
   end
 
+  def test_attr_encrypted_should_not_use_the_same_attribute_name_for_two_attributes_in_the_same_line
+    assert_not_equal User.encrypted_attributes[:email][:attribute], User.encrypted_attributes[:without_encoding][:attribute]
+  end
+
   def test_attr_encrypted_should_return_false_for_salt
     assert !User.attr_encrypted?('salt')
   end


### PR DESCRIPTION
Fixed an issue where specifying more than one attribute on the same line resulting in all of them having the same :attribute value in the options hash.
