### PR TITLE
Add compatibility with ruby 1.9 string encoding

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -189,7 +189,7 @@ module AttrEncrypted
     end
     
     
-    if RUBY_VERSION >= "1.9" and not options[:charset].nil?
+    if RUBY_VERSION >= "1.9" and not return_value.nil? and not options[:charset].nil? 
       return_value.force_encoding(options[:charset])
     else
       return_value


### PR DESCRIPTION
In some cases, under ruby 1.9 decryptor engine return value encoded as US-ASCII even if they contain UTF-8 data. It causes problems because string would be interpret as "\xC5\x81ukasz" not "Łukasz". Rails would then prevent displaying that value and will throw an error in the view.

This patch adds new parameter :charset that allows the user to force output encoding on selected attributes. It accepts anything accepted by String#force_encoding and special value of :default that just maps to the existing default encoding used by ruby. In Rails it is set in environment.rb as Encoding.default_internal but it is much cleaner and portable to use value like :default.

Sample usage:

attr_encrypted :myattr, (...), :charset => :default
attr_encrypted :myattr, (...), :charset => "utf-8"
