### PR TITLE
when assigning attributes, assign the non-encrypted ones first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 pkg
 Gemfile.lock
+coverage

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -6,6 +6,14 @@ if defined?(ActiveRecord::Base)
           base.class_eval do
             attr_encrypted_options[:encode] = true
             class << self; alias_method_chain :method_missing, :attr_encrypted; end
+
+            def assign_attributes_with_attr_encrypted(*args)
+              attributes = args.shift
+              encrypted_attributes = self.class.encrypted_attributes.keys
+              assign_attributes_without_attr_encrypted attributes.except(*encrypted_attributes), *args
+              assign_attributes_without_attr_encrypted attributes.slice(*encrypted_attributes), *args
+            end
+            alias_method_chain :assign_attributes, :attr_encrypted
           end
         end
 

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -105,7 +105,7 @@ class ActiveRecordTest < Test::Unit::TestCase
     assert_equal @person.password, %w(an array of strings)
   end
 
-  def _test_should_create_an_account_regardless_of_arguments_order
+  def test_should_create_an_account_regardless_of_arguments_order
     Account.create!(:key => SECRET_KEY, :password => "password")
     Account.create!(:password => "password" , :key => SECRET_KEY)
   end


### PR DESCRIPTION
(so that the key, iv, etc can be passed as attributes)
