### PR TITLE
Updates to Travis-CI configuration to fix Ruby 1.8.7 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+before_install:
+  - gem update bundler
+  - bundle --version
+  - gem update --system 2.1.11
+  - gem --version
 env:
   - ACTIVERECORD=2.3.8
   - ACTIVERECORD=3.0.0


### PR DESCRIPTION
Change adds workaround for failing build on Ruby 1.8.7:
- https://github.com/bundler/bundler/issues/2784
- https://github.com/rspec/rspec-expectations/commit/d2e3d97e5f0f1e23061f26376d2a752292c2a5d2
