### PR TITLE
Enable Ruby 2.0.0/Rails 3.2.12 Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - ACTIVERECORD=2.3.8
   - ACTIVERECORD=3.0.0
   - ACTIVERECORD=3.1.0
-  - ACTIVERECORD=3.2.0
+  - ACTIVERECORD=3.2.12
   - ACTIVERECORD=4.0.0
 matrix:
   exclude:
@@ -21,5 +21,4 @@ matrix:
       env: ACTIVERECORD=3.0.0
     - rvm: 2.0.0
       env: ACTIVERECORD=3.1.0
-    - rvm: 2.0.0
-      env: ACTIVERECORD=3.2.0
+


### PR DESCRIPTION
- Move minimum version of Rails 3.2.x to 3.2.12 since this is the first version of 3.2.x to officially support Ruby 2.0.0
- Remove the exclusion for Ruby 2.0.0/Rails 3.2.0
