### PR TITLE
Fixed attributes_with_attr_encrypted method.

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -14,7 +14,9 @@ if defined?(ActiveRecord::Base)
 
             if ::ActiveRecord::VERSION::STRING < "3.0" || ::ActiveRecord::VERSION::STRING > "3.1"
               def assign_attributes_with_attr_encrypted(*args)
-                attributes = args.shift.symbolize_keys
+                attributes = args.shift
+                return unless attributes.is_a?(Hash)
+                attributes.symbolize_keys
                 encrypted_attributes = self.class.encrypted_attributes.keys
                 assign_attributes_without_attr_encrypted attributes.except(*encrypted_attributes), *args
                 assign_attributes_without_attr_encrypted attributes.slice(*encrypted_attributes), *args
@@ -22,7 +24,9 @@ if defined?(ActiveRecord::Base)
               alias_method_chain :assign_attributes, :attr_encrypted
             else
               def attributes_with_attr_encrypted=(*args)
-                attributes = args.shift.symbolize_keys
+                attributes = args.shift
+                return unless attributes.is_a?(Hash)
+                attributes.symbolize_keys
                 encrypted_attributes = self.class.encrypted_attributes.keys
                 self.send(:attributes_without_attr_encrypted=, attributes.except(*encrypted_attributes), *args)
                 self.send(:attributes_without_attr_encrypted=, attributes.slice(*encrypted_attributes), *args)


### PR DESCRIPTION
- ActiveRecord passes two arguments, not one.
- The attributes_without_attr_encrypted method is not actually sent unless
  .send is explicitly used, because ActiveRecord is passing two
  arguments it's attempting assignment.
- Please see
  http://apidock.com/rails/v3.0.9/ActiveRecord/Base/attributes%3D
