### PR TITLE
Stops attr_encrypted from breaking strong parameters

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -14,7 +14,13 @@ if defined?(ActiveRecord::Base)
 
             if ::ActiveRecord::VERSION::STRING < "3.0" || ::ActiveRecord::VERSION::STRING > "3.1"
               def assign_attributes_with_attr_encrypted(*args)
-                attributes = args.shift.symbolize_keys
+                attributes = args.shift
+                attributes =
+                  if attributes.respond_to?(:with_indifferent_access)
+                    attributes.with_indifferent_access
+                  else
+                    attributes.symbolize_keys
+                  end
                 encrypted_attributes = self.class.encrypted_attributes.keys
                 assign_attributes_without_attr_encrypted attributes.except(*encrypted_attributes), *args
                 assign_attributes_without_attr_encrypted attributes.slice(*encrypted_attributes), *args
@@ -22,7 +28,7 @@ if defined?(ActiveRecord::Base)
               alias_method_chain :assign_attributes, :attr_encrypted
             else
               def attributes_with_attr_encrypted=(attributes)
-                attributes = attributes.symbolize_keys
+                attributes = attributes.with_indifferent_access
                 encrypted_attributes = self.class.encrypted_attributes.keys
                 self.attributes_without_attr_encrypted = attributes.except(*encrypted_attributes)
                 self.attributes_without_attr_encrypted = attributes.slice(*encrypted_attributes)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -65,6 +65,12 @@ class PersonWithSerialization < ActiveRecord::Base
   serialize :password
 end
 
+class UntrustedParams < ActiveSupport::HashWithIndifferentAccess
+  def permitted?
+    false
+  end
+end
+
 class ActiveRecordTest < Test::Unit::TestCase
 
   def setup
@@ -113,5 +119,10 @@ class ActiveRecordTest < Test::Unit::TestCase
   def test_should_create_an_account_regardless_of_arguments_order
     Account.create!(:key => SECRET_KEY, :password => "password")
     Account.create!(:password => "password" , :key => SECRET_KEY)
+  end
+
+  def test_should_not_break_strong_parameters
+    untrusted_params = UntrustedParams.new(:id => 42)
+    assert_raise(ActiveModel::ForbiddenAttributesError) { Person.new(untrusted_params) }
   end
 end


### PR DESCRIPTION
attr_encrypted's current behavior is to call `symbolize_keys`
on the attributes that it's given. It then passes the resulting
hash to the underlying ActiveRecord `assign_attributes` method.
This, however, entirely defeats the security of strong parameters
in Rails 4 (and Rails 3 with the strong_parameters gem). Calling
`symbolize_keys` on an instance of ActionController::Parameters
returns a plain Hash, which does not respond to `permitted?`.

This patch will instead call `with_indifferent_access` on the
passed-in attributes, if that method is available. (If not, it
falls back to `symbolize_keys`.) `with_indifferent_access` has
been in ActiveSupport since Rails 3.0, and the strong parameters
gem will not work with an earlier version of Rails, so this
should work wherever strong parameters do.
