### PR TITLE
Encrypt empty too

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -75,6 +75,9 @@ module AttrEncrypted
   #                        is the recommended mode for new deployments.
   #                        Defaults to <tt>:single_iv_and_salt</tt>.
   #
+  #   :allow_empty      => Attributes which have nil or empty string values will not be encrypted unless this option
+  #                        has a truthy value.
+  #
   # You can specify your own default options
   #
   #   class User
@@ -117,7 +120,8 @@ module AttrEncrypted
       :encryptor        => Encryptor,
       :encrypt_method   => 'encrypt',
       :decrypt_method   => 'decrypt',
-      :mode             => :single_iv_and_salt
+      :mode             => :single_iv_and_salt,
+      :allow_empty      => false,
     }.merge!(attr_encrypted_options).merge!(attributes.last.is_a?(Hash) ? attributes.pop : {})
 
     options[:encode] = options[:default_encoding] if options[:encode] == true
@@ -217,7 +221,7 @@ module AttrEncrypted
   #   encrypted_email = User.encrypt(:email, 'test@example.com')
   def encrypt(attribute, value, options = {})
     options = encrypted_attributes[attribute.to_sym].merge(options)
-    if options[:if] && !options[:unless] && not_empty?(value)
+    if options[:if] && !options[:unless] && (options[:allow_empty] || not_empty?(value))
       value = options[:marshal] ? options[:marshaler].send(options[:dump_method], value) : value.to_s
       encrypted_value = options[:encryptor].send(options[:encrypt_method], options.merge!(:value => value))
       encrypted_value = [encrypted_value].pack(options[:encode]) if options[:encode]

--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -191,7 +191,7 @@ module AttrEncrypted
   #   email = User.decrypt(:email, 'SOME_ENCRYPTED_EMAIL_STRING')
   def decrypt(attribute, encrypted_value, options = {})
     options = encrypted_attributes[attribute.to_sym].merge(options)
-    if options[:if] && !options[:unless] && !encrypted_value.nil? && !(encrypted_value.is_a?(String) && encrypted_value.empty?)
+    if options[:if] && !options[:unless] && not_empty?(encrypted_value)
       encrypted_value = encrypted_value.unpack(options[:encode]).first if options[:encode]
       value = options[:encryptor].send(options[:decrypt_method], options.merge!(:value => encrypted_value))
       if options[:marshal]
@@ -217,7 +217,7 @@ module AttrEncrypted
   #   encrypted_email = User.encrypt(:email, 'test@example.com')
   def encrypt(attribute, value, options = {})
     options = encrypted_attributes[attribute.to_sym].merge(options)
-    if options[:if] && !options[:unless] && !value.nil? && !(value.is_a?(String) && value.empty?)
+    if options[:if] && !options[:unless] && not_empty?(value)
       value = options[:marshal] ? options[:marshaler].send(options[:dump_method], value) : value.to_s
       encrypted_value = options[:encryptor].send(options[:encrypt_method], options.merge!(:value => value))
       encrypted_value = [encrypted_value].pack(options[:encode]) if options[:encode]
@@ -225,6 +225,10 @@ module AttrEncrypted
     else
       value
     end
+  end
+
+  def not_empty?(value)
+    !value.nil? && !(value.is_a?(String) && value.empty?)
   end
 
   # Contains a hash of encrypted attributes with virtual attribute names as keys

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -27,6 +27,7 @@ class User
   attr_encrypted :with_true_unless, :key => SECRET_KEY, :unless => true
   attr_encrypted :with_false_unless, :key => SECRET_KEY, :unless => false
   attr_encrypted :with_if_changed, :key => SECRET_KEY, :if => :should_encrypt
+  attr_encrypted :with_allow_empty, :key => SECRET_KEY, :allow_empty => true, :encryptor => SillyEncryptor, :encrypt_method => :silly_encrypt, :decrypt_method => :silly_decrypt, :some_arg => 'test'
 
   attr_encryptor :aliased, :key => SECRET_KEY
 
@@ -252,6 +253,14 @@ class AttrEncryptedTest < Test::Unit::TestCase
     @user.with_true_unless = 'testing'
     assert_not_nil @user.encrypted_with_true_unless
     assert_equal 'testing', @user.encrypted_with_true_unless
+  end
+
+  def test_should_encrypt_empty_with_empty_allowed
+    @user = User.new
+    assert_nil @user.encrypted_with_allow_empty
+    @user.with_allow_empty = ''
+    assert_not_nil @user.encrypted_with_allow_empty
+    assert_equal '', @user.with_allow_empty
   end
 
   def test_should_work_with_aliased_attr_encryptor


### PR DESCRIPTION
@sbfaulkner this adds an option that allows encrypting empty strings, which is useful in cases where it should not be apparent from an inspection of the cipher that it is present or not.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/attr-encrypted/attr_encrypted/116)
<!-- Reviewable:end -->
