### PR TITLE
107 protected attributes load order

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -1,3 +1,4 @@
+require 'attr_encrypted/railtie' if defined? Rails
 require 'encryptor'
 
 # Adds attr_accessors that encrypt and decrypt an object's attributes
@@ -345,7 +346,3 @@ module AttrEncrypted
       end
   end
 end
-
-Object.extend AttrEncrypted
-
-Dir[File.join(File.dirname(__FILE__), 'attr_encrypted', 'adapters', '*.rb')].each { |adapter| require adapter }

--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -1,4 +1,4 @@
-require 'attr_encrypted/railtie' if defined? Rails
+require 'attr_encrypted/railtie' if defined? ::Rails::Railtie
 require 'encryptor'
 
 # Adds attr_accessors that encrypt and decrypt an object's attributes
@@ -345,4 +345,10 @@ module AttrEncrypted
         self.class.encrypted_attributes[attribute.to_sym] = self.class.encrypted_attributes[attribute.to_sym].merge(:salt => salt)
       end
   end
+end
+
+unless defined? ::Rails::Railtie
+  Object.extend AttrEncrypted
+
+  Dir[File.join(File.dirname(__FILE__), 'attr_encrypted', 'adapters', '*.rb')].each { |adapter| require adapter }
 end

--- a/lib/attr_encrypted/railtie.rb
+++ b/lib/attr_encrypted/railtie.rb
@@ -1,0 +1,11 @@
+require 'rails/railtie'
+
+module AttrEncrypted
+  class Railtie < ::Rails::Railtie
+    config.after_initialize do
+      Object.extend AttrEncrypted
+
+      Dir[File.join(File.dirname(__FILE__), 'attr_encrypted', 'adapters', '*.rb')].each { |adapter| require adapter }
+    end
+  end
+end

--- a/lib/attr_encrypted/railtie.rb
+++ b/lib/attr_encrypted/railtie.rb
@@ -2,7 +2,7 @@ require 'rails/railtie'
 
 module AttrEncrypted
   class Railtie < ::Rails::Railtie
-    config.after_initialize do
+    initializer "attr_encrypted.active_record", :after => "active_record.set_configs" do |app|
       Object.extend AttrEncrypted
 
       Dir[File.join(File.dirname(__FILE__), 'attr_encrypted', 'adapters', '*.rb')].each { |adapter| require adapter }


### PR DESCRIPTION
A fix for https://github.com/attr-encrypted/attr_encrypted/issues/107, the issue where protected_attributes and attr_encrypted are loading in the wrong order in Rails 4.  The proper way to handle the load order of gems in Rails 3 and up is to use Railties and hook to initializers.

I've added a Railtie to attr_encrypted that hooks in after "active_record.set_configs", which is the event that protected_attributes hooks in before.  I moved the #extend and #require calls into the Railtie initializer.  This ensures that the gem loads at a consistent, well-known time in the Rails bootstrap process.

I would include a unit test for this, but I'm not sure how to write an effective one to test load order.  I'm open to suggestions.