### PR TITLE
Remove Ruby 1.8.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 env:
@@ -11,8 +10,6 @@ env:
   - ACTIVERECORD=4.0.0
 matrix:
   exclude:
-    - rvm: 1.8.7
-      env: ACTIVERECORD=4.0.0
     - rvm: 1.9.3
       env: ACTIVERECORD=2.3.8
     - rvm: 2.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
-require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 desc 'Test the attr_encrypted gem.'
 Rake::TestTask.new(:test) do |t|
@@ -18,16 +17,5 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-if RUBY_VERSION < '1.9.3'
-  require 'rcov/rcovtask'
-
-  task :rcov do
-    sh "rcov -o coverage/rcov --exclude '^(?!lib)' " + FileList[ 'test/**/*_test.rb' ].join(' ')
-  end
-
-  desc 'Default: run unit tests under rcov.'
-  task :default => :rcov
-else
-  desc 'Default: run unit tests.'
-  task :default => :test
-end
+desc 'Default: run unit tests.'
+task :default => :test

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -26,34 +26,23 @@ Gem::Specification.new do |s|
   s.files      = Dir['{bin,lib}/**/*'] + %w(MIT-LICENSE Rakefile README.rdoc)
   s.test_files = Dir['test/**/*']
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.add_dependency('encryptor', ['>= 1.3.0'])
   # support for testing with specific active record version
   activerecord_version = if ENV.key?('ACTIVERECORD')
     "~> #{ENV['ACTIVERECORD']}"
   else
-    ['>= 2.0.0'].tap do |version|
-      if RUBY_VERSION < '1.9.3'
-        # For Ruby 1.8.7 CI builds, we must force a dependency on the latest Ruby
-        # 1.8.7-compatible version of ActiveSupport (i.e. pre-4.0.0).
-        version.push('< 4.0.0')
-      end
-    end
+    '>= 2.0.0'
   end
   s.add_development_dependency('activerecord', activerecord_version)
   s.add_development_dependency('actionpack', activerecord_version)
   s.add_development_dependency('datamapper')
   s.add_development_dependency('mocha', '~> 1.0.0')
+  s.add_development_dependency('rake')
   s.add_development_dependency('sequel')
   s.add_development_dependency('sqlite3')
   s.add_development_dependency('dm-sqlite-adapter')
-  # Lock to "rake" version 0.9.2.2 in order to use deprecated "rake/rdoctask".
-  # Once we drop official support for Ruby 1.8.7, we can loosen this constraint
-  # and allow our dependencies to "float" to the latest version of "rake".
-  s.add_development_dependency('rake', '0.9.2.2')
-  if RUBY_VERSION < '1.9.3'
-    s.add_development_dependency('rcov')
-  else
-    s.add_development_dependency('simplecov')
-    s.add_development_dependency('simplecov-rcov')
-  end
+  s.add_development_dependency('simplecov')
+  s.add_development_dependency('simplecov-rcov')
 end

--- a/test/compatibility_test.rb
+++ b/test/compatibility_test.rb
@@ -89,40 +89,20 @@ class CompatibilityTest < Test::Unit::TestCase
 
   def test_marshalling_backwards_compatibility
     self.class.setup
-    # Marshalling formats changed significantly from Ruby 1.8.7 to 1.9.3.
-    # Also, Date class did not correctly support marshalling pre-1.9.3, so here
-    # we just marshal it as a string in the Ruby 1.8.7 case.
-    if RUBY_VERSION < '1.9.3'
-      pet = MarshallingPet.create!(
-        :name => 'Fido',
-        :encrypted_nickname => 'NhpLBIp3aKRzNZrUgUfVuceYi4x+8lE3wUsVCSI9BcU=',
-        :encrypted_nickname_iv => 'wpQqrj3KN16fN6PsAerUTA==',
-        :encrypted_nickname_salt => '8f1a62d274ca8a3a',
-        :encrypted_birthdate => '4nbCEzcj6CjLd3B9liKm9Q==',
-        :encrypted_birthdate_iv => 'Vt10PQZMrbamh/gmjSLdkQ==',
-        :encrypted_birthdate_salt => 'cfb245a3df76404f'
-      )
-    else
-      pet = MarshallingPet.create!(
-        :name => 'Fido',
-        :encrypted_nickname => 'EsQScJYkPw80vVGvKWkE37Px99HHpXPFjoEPTNa4rbs=',
-        :encrypted_nickname_iv => 'fNq1OZcGvty4KfcvGTcFSw==',
-        :encrypted_nickname_salt => '733b459b7d34c217',
-        :encrypted_birthdate => '+VUlKQGfNWkOgCwI4hv+3qlGIwh9h6cJ/ranJlaxvU+xxQdL3H3cOzTcI2rkYkdR',
-        :encrypted_birthdate_iv => 'Ka+zF/SwEYZKwVa24lvFfA==',
-        :encrypted_birthdate_salt => 'd5e892d5bbd81566'
-      )
-    end
+    pet = MarshallingPet.create!(
+      :name => 'Fido',
+      :encrypted_nickname => 'EsQScJYkPw80vVGvKWkE37Px99HHpXPFjoEPTNa4rbs=',
+      :encrypted_nickname_iv => 'fNq1OZcGvty4KfcvGTcFSw==',
+      :encrypted_nickname_salt => '733b459b7d34c217',
+      :encrypted_birthdate => '+VUlKQGfNWkOgCwI4hv+3qlGIwh9h6cJ/ranJlaxvU+xxQdL3H3cOzTcI2rkYkdR',
+      :encrypted_birthdate_iv => 'Ka+zF/SwEYZKwVa24lvFfA==',
+      :encrypted_birthdate_salt => 'd5e892d5bbd81566'
+    )
 
     assert_equal 'Fido', pet.name
     assert_equal 'Mummy\'s little helper', pet.nickname
 
-    # See earlier comment.
-    if RUBY_VERSION < '1.9.3'
-      assert_equal '2011-07-09', pet.birthdate
-    else
-      assert_equal Date.new(2011, 7, 9), pet.birthdate
-    end
+    assert_equal Date.new(2011, 7, 9), pet.birthdate
   end
 end
 

--- a/test/legacy_compatibility_test.rb
+++ b/test/legacy_compatibility_test.rb
@@ -74,32 +74,16 @@ class LegacyCompatibilityTest < Test::Unit::TestCase
 
   def test_marshalling_backwards_compatibility
     self.class.setup
-    # Marshalling formats changed significantly from Ruby 1.8.7 to 1.9.3.
-    # Also, Date class did not correctly support marshalling pre-1.9.3, so here
-    # we just marshal it as a string in the Ruby 1.8.7 case.
-    if RUBY_VERSION < '1.9.3'
-      pet = LegacyMarshallingPet.create!(
-        :name => 'Fido',
-        :encrypted_nickname => 'xhayxWxfkfbNyOS2w1qBMPV49Gfvs6dcZFBopMK2zQA=',
-        :encrypted_birthdate => 'f4ufXun4GXzahH4MQ1eTBQ=='
-      )
-    else
-      pet = LegacyMarshallingPet.create!(
-        :name => 'Fido',
-        :encrypted_nickname => '7RwoT64in4H+fGVBPYtRcN0K4RtriIy1EP4nDojUa8g=',
-        :encrypted_birthdate => 'bSp9sJhXQSp2QlNZHiujtcK4lRVBE8HQhn1y7moQ63bGJR20hvRSZ73ePAmm+wc5'
-      )
-    end
+    pet = LegacyMarshallingPet.create!(
+      :name => 'Fido',
+      :encrypted_nickname => '7RwoT64in4H+fGVBPYtRcN0K4RtriIy1EP4nDojUa8g=',
+      :encrypted_birthdate => 'bSp9sJhXQSp2QlNZHiujtcK4lRVBE8HQhn1y7moQ63bGJR20hvRSZ73ePAmm+wc5'
+    )
 
     assert_equal 'Fido', pet.name
     assert_equal 'Mummy\'s little helper', pet.nickname
 
-    # See earlier comment.
-    if RUBY_VERSION < '1.9.3'
-      assert_equal '2011-07-09', pet.birthdate
-    else
-      assert_equal Date.new(2011, 7, 9), pet.birthdate
-    end
+    assert_equal Date.new(2011, 7, 9), pet.birthdate
   end
 end
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,52 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env sh -e
 
-set -e
-
-export RBENV_VERSION=ree-1.8.7-2012.02
-rbenv version
-
-export ACTIVERECORD=2.3.8
-bundle
-bundle exec rake
-export ACTIVERECORD=3.0.0
-bundle
-bundle exec rake
-export ACTIVERECORD=3.1.0
-bundle
-bundle exec rake
-export ACTIVERECORD=3.2.0
-bundle
-bundle exec rake
-
-export RBENV_VERSION=1.9.3-p484
-rbenv version
-
-export ACTIVERECORD=3.0.0
-bundle
-bundle exec rake
-export ACTIVERECORD=3.1.0
-bundle
-bundle exec rake
-export ACTIVERECORD=3.2.0
-bundle
-bundle exec rake
-export ACTIVERECORD=4.0.0
-bundle
-bundle exec rake
-
-export RBENV_VERSION=2.0.0-p353
-rbenv version
-
-export ACTIVERECORD=3.2.0
-bundle
-bundle exec rake
-export ACTIVERECORD=4.0.0
-bundle
-bundle exec rake
-
-export RBENV_VERSION=2.1.0
-rbenv version
-
-export ACTIVERECORD=4.0.0
-bundle
-bundle exec rake
+for RUBY in 1.9.3 2.0.0 2.1 2.2
+do
+  for RAILS in 2.3.8 3.0.0 3.1.0 3.2.0 4.0.0 4.1.0 4.2.0
+  do
+    if [[ $RUBY -gt 1.9.3 && $RAILS -lt 4.0.0 ]]; then
+      continue
+    fi
+    RBENV_VERSION=$RUBY ACTIVERECORD=$RAILS bundle && bundle exec rake
+  done
+done

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,15 +1,13 @@
-if RUBY_VERSION >= '1.9.3'
-  require 'simplecov'
-  require 'simplecov-rcov'
+require 'simplecov'
+require 'simplecov-rcov'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::RcovFormatter,
-  ]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::RcovFormatter,
+]
 
-  SimpleCov.start do
-    add_filter 'test'
-  end
+SimpleCov.start do
+  add_filter 'test'
 end
 
 require 'test/unit'


### PR DESCRIPTION
@billymonk @saghaulor this should fix the current CI breakage (which is caused by rails 2.3 bundling a version of i18n that needs ruby `>= 1.9.3`.