### PR TITLE
Replaced before_type_cast method aliasing with conditional definition.

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -49,7 +49,12 @@ if defined?(ActiveRecord::Base)
           # <tt>attr_encrypted</tt> method
           def attr_encrypted(*attrs)
             super
-            attrs.reject { |attr| attr.is_a?(Hash) }.each { |attr| alias_method "#{attr}_before_type_cast", attr }
+            attr = attrs.first
+            unless method_defined? "#{attr}_before_type_cast"
+              define_method("#{attr}_before_type_cast") do
+                send(attr)
+              end
+            end
           end
 
           def attribute_instance_methods_as_symbols


### PR DESCRIPTION
- Aliasing before_type_cast means that we can't alter the behavior in
  any way.
- Now we define the behavior to be backwards compatible, however, we can
  override the behavior if necessary.