### PR TITLE
Now using random bytes for salt instead of hex chars.

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -341,7 +341,8 @@ module AttrEncrypted
 
       def load_salt_for_attribute(attribute)
         encrypted_attribute_name = self.class.encrypted_attributes[attribute.to_sym][:attribute]
-        salt = send("#{encrypted_attribute_name}_salt") || send("#{encrypted_attribute_name}_salt=", SecureRandom.hex)
+        salt = send("#{encrypted_attribute_name}_salt") || send("#{encrypted_attribute_name}_salt=", [SecureRandom.random_bytes].pack("m"))
+        salt = salt.size > 16 ? salt.unpack("m").first : salt
         self.class.encrypted_attributes[attribute.to_sym] = self.class.encrypted_attributes[attribute.to_sym].merge(:salt => salt)
       end
   end

--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -341,9 +341,18 @@ module AttrEncrypted
 
       def load_salt_for_attribute(attribute)
         encrypted_attribute_name = self.class.encrypted_attributes[attribute.to_sym][:attribute]
-        salt = send("#{encrypted_attribute_name}_salt") || send("#{encrypted_attribute_name}_salt=", [SecureRandom.random_bytes].pack("m"))
-        salt = salt.size > 16 ? salt.unpack("m").first : salt
+        salt = send("#{encrypted_attribute_name}_salt") || send("#{encrypted_attribute_name}_salt=", generate_random_base64_encoded_salt)
+        salt = decode_salt_if_encoded(salt)
         self.class.encrypted_attributes[attribute.to_sym] = self.class.encrypted_attributes[attribute.to_sym].merge(:salt => salt)
+      end
+
+      def generate_random_base64_encoded_salt
+        prefix = '_'
+        prefix + [SecureRandom.random_bytes].pack("m")
+      end
+
+      def decode_salt_if_encoded(salt)
+        salt.slice(0).eql?('_') ? salt.unpack("m").first : salt
       end
   end
 

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -164,7 +164,7 @@ class AttrEncryptedTest < Minitest::Test
     assert_nil @user.ssn_encrypted
     @user.ssn = 'testing'
     refute_nil @user.ssn_encrypted
-    encrypted =  Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.ssn_encrypted_iv.unpack("m").first, :salt => @user.ssn_encrypted_salt )
+    encrypted =  Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.ssn_encrypted_iv.unpack("m").first, :salt => @user.ssn_encrypted_salt.unpack("m").first )
     assert_equal encrypted, @user.ssn_encrypted
   end
 
@@ -173,7 +173,7 @@ class AttrEncryptedTest < Minitest::Test
     assert_nil @user.crypted_password_test
     @user.password = 'testing'
     refute_nil @user.crypted_password_test
-    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.crypted_password_test_iv.unpack("m").first, :salt =>  @user.crypted_password_test_salt)
+    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.crypted_password_test_iv.unpack("m").first, :salt =>  @user.crypted_password_test_salt.unpack("m").first)
     assert_equal encrypted, @user.crypted_password_test
   end
 
@@ -182,7 +182,7 @@ class AttrEncryptedTest < Minitest::Test
     assert_nil @user.crypted_password_test
     @user.password = 'testing'
     refute_nil @user.crypted_password_test
-    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.crypted_password_test_iv.unpack("m").first, :salt => @user.crypted_password_test_salt)
+    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.crypted_password_test_iv.unpack("m").first, :salt => @user.crypted_password_test_salt.unpack("m").first)
     assert_equal encrypted, @user.crypted_password_test
   end
 
@@ -225,7 +225,7 @@ class AttrEncryptedTest < Minitest::Test
     assert_nil @user.encrypted_with_true_if
     @user.with_true_if = 'testing'
     refute_nil @user.encrypted_with_true_if
-    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.encrypted_with_true_if_iv.unpack("m").first, :salt => @user.encrypted_with_true_if_salt)
+    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.encrypted_with_true_if_iv.unpack("m").first, :salt => @user.encrypted_with_true_if_salt.unpack("m").first)
     assert_equal encrypted, @user.encrypted_with_true_if
   end
 
@@ -242,7 +242,7 @@ class AttrEncryptedTest < Minitest::Test
     assert_nil @user.encrypted_with_false_unless
     @user.with_false_unless = 'testing'
     refute_nil @user.encrypted_with_false_unless
-    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.encrypted_with_false_unless_iv.unpack("m").first, :salt => @user.encrypted_with_false_unless_salt)
+    encrypted = Encryptor.encrypt(:value => 'testing', :key => SECRET_KEY, :iv => @user.encrypted_with_false_unless_iv.unpack("m").first, :salt => @user.encrypted_with_false_unless_salt.unpack("m").first)
     assert_equal encrypted,  @user.encrypted_with_false_unless
   end
 


### PR DESCRIPTION
- Thanks @pauljm for pointing out that the key space of the salt was
  significantly smaller than it should be because we were using hex
  chars.
- This change should be backwards compatible.
- Fixes #133.