### PR TITLE
Only lookup ActiveRecord column names when connected to the DB.	

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -56,7 +56,11 @@ if defined?(ActiveRecord::Base)
             # We add accessor methods of the db columns to the list of instance
             # methods returned to let ActiveRecord define the accessor methods
             # for the db columns
-            if table_exists?
+            
+            # Use with_connection so the connection doesn't stay pinned to the thread.
+ 	          connected = ::ActiveRecord::Base.connection_pool.with_connection(&:active?) rescue false
+
+            if connected && table_exists?
               columns_hash.keys.inject(super) {|instance_methods, column_name| instance_methods.concat [column_name.to_sym, :"#{column_name}="]}
             else
               super

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -58,8 +58,8 @@ if defined?(ActiveRecord::Base)
             # for the db columns
             
             # Use with_connection so the connection doesn't stay pinned to the thread.
- 	          connected = ::ActiveRecord::Base.connection_pool.with_connection(&:active?) rescue false
-
+            connected = ::ActiveRecord::Base.connection_pool.with_connection(&:active?) rescue false
+            
             if connected && table_exists?
               columns_hash.keys.inject(super) {|instance_methods, column_name| instance_methods.concat [column_name.to_sym, :"#{column_name}="]}
             else


### PR DESCRIPTION
In our setup, we run `rake assets:precompile` without having a DB server running. We were seeing the command fail because it loads the entire Rails app, one of our models calls `attr_encrypted`, and `attr_encrypted` uses `table_exists?`, which depends on an active DB connection.