### PR TITLE
Add support for <attribute>_was

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -153,6 +153,10 @@ module AttrEncrypted
         value.respond_to?(:empty?) ? !value.empty? : !!value
       end
 
+      define_method("#{attribute}_was") do
+        decrypt(attribute, send("#{encrypted_attribute_name}_was"))
+      end
+
       encrypted_attributes[attribute.to_sym] = options.merge(:attribute => encrypted_attribute_name)
     end
   end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -264,4 +264,14 @@ class ActiveRecordTest < Minitest::Test
     assert_equal pm, result
     assert_equal 'Winston Churchill', pm.name
   end
+
+  def test_should_support_attribute_was
+    pm = PrimeMinister.new(:name => 'Winston Churchill')
+    pm.save!
+    assert_equal 'Winston Churchill', pm.name
+
+    pm.name = 'John Doe'
+    assert_equal 'John Doe', pm.name
+    assert_equal 'Winston Churchill', pm.name_was
+  end
 end


### PR DESCRIPTION
This PR adds support for ActiveRecord's `<attribute>_was` as is required for compatibility with the Devise gem. Test included. The current implementation is somewhat inefficient as it decrypts on each access, which is ok for our use case. Please let me know if you think that this should be optimized before merging.