### PR TITLE
Change how attr_encrypted is added to classes.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -13,10 +13,18 @@ It works with ANY class, however, you get a few extra features when you're using
 == Usage
 
 === Basic
-
 Encrypting attributes has never been easier:
 
+If you're using an ORM like <tt>ActiveRecord</tt>, <tt>DataMapper</tt>, or <tt>Sequel</tt>, using attr_encryped is easy:
+
   class User
+    attr_encrypted :ssn, :key => 'a secret key'
+  end
+
+If you're using a PORO, you have to do a little bit more work by extending the class:
+
+  class User
+    extend AttrEncrypted
     attr_accessor :name
     attr_encrypted :ssn, :key => 'a secret key'
   
@@ -31,6 +39,7 @@ Encrypting attributes has never been easier:
   
   @user = User.new
   @user.ssn = '123-45-6789'
+  @user.ssn # returns the unencrypted object ie. '123-45-6789'
   @user.encrypted_ssn # returns the encrypted version of :ssn
   @user.save
   

--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -364,6 +364,5 @@ module AttrEncrypted
 
 end
 
-Object.extend AttrEncrypted
 
 Dir[File.join(File.dirname(__FILE__), 'attr_encrypted', 'adapters', '*.rb')].each { |adapter| require adapter }

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -101,5 +101,6 @@ if defined?(ActiveRecord::Base)
     end
   end
 
+  ActiveRecord::Base.extend AttrEncrypted
   ActiveRecord::Base.extend AttrEncrypted::Adapters::ActiveRecord
 end

--- a/lib/attr_encrypted/adapters/data_mapper.rb
+++ b/lib/attr_encrypted/adapters/data_mapper.rb
@@ -11,6 +11,7 @@ if defined?(DataMapper)
 
         def included_with_attr_encrypted(base)
           included_without_attr_encrypted(base)
+          base.extend AttrEncrypted
           base.attr_encrypted_options[:encode] = true
         end
       end

--- a/lib/attr_encrypted/adapters/sequel.rb
+++ b/lib/attr_encrypted/adapters/sequel.rb
@@ -9,5 +9,6 @@ if defined?(Sequel)
     end
   end
 
+  Sequel::Model.extend AttrEncrypted
   Sequel::Model.extend AttrEncrypted::Adapters::Sequel
 end

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -12,6 +12,7 @@ class SillyEncryptor
 end
 
 class User
+  extend AttrEncrypted
   self.attr_encrypted_options[:key] = Proc.new { |user| SECRET_KEY } # default key
   self.attr_encrypted_options[:mode] = :per_attribute_iv_and_salt
 
@@ -48,6 +49,7 @@ class Admin < User
 end
 
 class SomeOtherClass
+  extend AttrEncrypted
   def self.call(object)
     object.class
   end
@@ -201,23 +203,24 @@ class AttrEncryptedTest < Minitest::Test
   end
 
   def test_should_evaluate_a_symbol_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, :class)
+    assert_equal SomeOtherClass, SomeOtherClass.new.send(:evaluate_attr_encrypted_option, :class)
   end
 
   def test_should_evaluate_a_proc_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, proc { |object| object.class })
+    assert_equal SomeOtherClass, SomeOtherClass.new.send(:evaluate_attr_encrypted_option, proc { |object| object.class })
   end
 
   def test_should_evaluate_a_lambda_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, lambda { |object| object.class })
+    assert_equal SomeOtherClass, SomeOtherClass.new.send(:evaluate_attr_encrypted_option, lambda { |object| object.class })
   end
 
   def test_should_evaluate_a_method_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, SomeOtherClass.method(:call))
+    assert_equal SomeOtherClass, SomeOtherClass.new.send(:evaluate_attr_encrypted_option, SomeOtherClass.method(:call))
   end
 
   def test_should_return_a_string_option
-    assert_equal 'Object', Object.new.send(:evaluate_attr_encrypted_option, 'Object')
+    class_string = 'SomeOtherClass'
+    assert_equal class_string, SomeOtherClass.new.send(:evaluate_attr_encrypted_option, class_string)
   end
 
   def test_should_encrypt_with_true_if

--- a/test/legacy_attr_encrypted_test.rb
+++ b/test/legacy_attr_encrypted_test.rb
@@ -12,6 +12,7 @@ class LegacySillyEncryptor
 end
 
 class LegacyUser
+  extend AttrEncrypted
   self.attr_encrypted_options[:key] = Proc.new { |user| user.class.to_s } # default key
 
   attr_encrypted :email, :without_encoding, :key => 'secret key'
@@ -43,6 +44,7 @@ class LegacyAdmin < LegacyUser
 end
 
 class LegacySomeOtherClass
+  extend AttrEncrypted
   def self.call(object)
     object.class
   end
@@ -208,23 +210,24 @@ class LegacyAttrEncryptedTest < Minitest::Test
   end
 
   def test_should_evaluate_a_symbol_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, :class)
+    assert_equal LegacySomeOtherClass, LegacySomeOtherClass.new.send(:evaluate_attr_encrypted_option, :class)
   end
 
   def test_should_evaluate_a_proc_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, proc { |object| object.class })
+    assert_equal LegacySomeOtherClass, LegacySomeOtherClass.new.send(:evaluate_attr_encrypted_option, proc { |object| object.class })
   end
 
   def test_should_evaluate_a_lambda_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, lambda { |object| object.class })
+    assert_equal LegacySomeOtherClass, LegacySomeOtherClass.new.send(:evaluate_attr_encrypted_option, lambda { |object| object.class })
   end
 
   def test_should_evaluate_a_method_option
-    assert_equal Object, Object.new.send(:evaluate_attr_encrypted_option, LegacySomeOtherClass.method(:call))
+    assert_equal LegacySomeOtherClass, LegacySomeOtherClass.new.send(:evaluate_attr_encrypted_option, LegacySomeOtherClass.method(:call))
   end
 
   def test_should_return_a_string_option
-    assert_equal 'Object', Object.new.send(:evaluate_attr_encrypted_option, 'Object')
+    class_string = 'LegacySomeOtherClass'
+    assert_equal class_string, LegacySomeOtherClass.new.send(:evaluate_attr_encrypted_option, class_string)
   end
 
   def test_should_encrypt_with_true_if


### PR DESCRIPTION
- This change should be seamless for ORM users. For users that use
  attr_encrypted with POROs, you'll have to extend your class with the
  AttrEncrypted module.
- This change resolves #57, and resolves #108