### PR TITLE
Add _changed? predicate method

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -50,6 +50,12 @@ if defined?(ActiveRecord::Base)
           def attr_encrypted(*attrs)
             super
             attrs.reject { |attr| attr.is_a?(Hash) }.each { |attr| alias_method "#{attr}_before_type_cast", attr }
+
+            encrypted_attributes.each do |attribute, options|
+              define_method("#{attribute}_changed?") do
+                send(attribute) != decrypt(attribute, send("#{options[:attribute]}_was"))
+              end
+            end
           end
 
           def attribute_instance_methods_as_symbols

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -164,6 +164,13 @@ class ActiveRecordTest < Minitest::Test
     assert_equal account.key, hash
   end
 
+  def test_should_create_changed_predicate
+    person = Person.create!(:email => 'test@example.com')
+    assert !person.email_changed?
+    person.email = 'test2@example.com'
+    assert person.email_changed?
+  end
+
   if ::ActiveRecord::VERSION::STRING > "4.0"
     def test_should_assign_attributes
       @user = UserWithProtectedAttribute.new :login => 'login', :is_admin => false


### PR DESCRIPTION
This adds the `ActiveRecord` `<ATTRIBUTE>_changed?` methods to improve compatibility with the AR API.