### PR TITLE
Fix attr_was method.

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -59,8 +59,10 @@ if defined?(ActiveRecord::Base)
             end
 
             define_method("#{attr}_was") do
-              iv_and_salt = { iv: send("#{options[:attribute]}_iv_was"), salt: send("#{options[:attribute]}_salt_was"), operation: :decrypting }
-              encrypted_attributes[attr].merge!(iv_and_salt)
+              attr_was_options = { operation: :decrypting }
+              attr_was_options[:iv]= send("#{options[:attribute]}_iv_was") if respond_to?("#{options[:attribute]}_iv_was")
+              attr_was_options[:salt]= send("#{options[:attribute]}_salt_was") if respond_to?("#{options[:attribute]}_salt_was")
+              encrypted_attributes[attr].merge!(attr_was_options)
               evaluated_options = evaluated_attr_encrypted_options_for(attr)
               [:iv, :salt, :operation].each { |key| encrypted_attributes[attr].delete(key) }
               self.class.decrypt(attr, send("#{options[:attribute]}_was"), evaluated_options)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -192,6 +192,12 @@ class ActiveRecordTest < Minitest::Test
     assert_equal original_email, person.email_was
     person.email = 'test2@example.com'
     assert_equal original_email, person.email_was
+    old_pm_name = "Winston Churchill"
+    pm = PrimeMinister.create!(name: old_pm_name)
+    assert_equal old_pm_name, pm.name_was
+    old_zipcode = "90210"
+    address = Address.create!(zipcode: old_zipcode, mode: "single_iv_and_salt")
+    assert_equal old_zipcode, address.zipcode_was
   end
 
   if ::ActiveRecord::VERSION::STRING > "4.0"


### PR DESCRIPTION
- If the encrypted_attr_iv or encrypted_attr_salt column are missing,
  then ActiveRecord won't define methods for them. Consequently,
  attempting to call those undefined methods will not work. As such, we
  should only call those methods when they're defined.
- Fixes #209