### PR TITLE
Remove silence stream - fixes tests for Rails5

### DIFF
--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -3,40 +3,38 @@ require_relative 'test_helper'
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 
 def create_tables
-  silence_stream(STDOUT) do
-    ActiveRecord::Schema.define(version: 1) do
-      create_table :people do |t|
-        t.string   :encrypted_email
-        t.string   :password
-        t.string   :encrypted_credentials
-        t.binary   :salt
-        t.binary   :key_iv
-        t.string   :encrypted_email_salt
-        t.string   :encrypted_credentials_salt
-        t.string   :encrypted_email_iv
-        t.string   :encrypted_credentials_iv
-      end
-      create_table :accounts do |t|
-        t.string :encrypted_password
-        t.string :encrypted_password_iv
-        t.string :encrypted_password_salt
-      end
-      create_table :users do |t|
-        t.string :login
-        t.string :encrypted_password
-        t.string :encrypted_password_iv
-        t.boolean :is_admin
-      end
-      create_table :prime_ministers do |t|
-        t.string :encrypted_name
-        t.string :encrypted_name_iv
-      end
-      create_table :addresses do |t|
-        t.binary :encrypted_street
-        t.binary :encrypted_street_iv
-        t.binary :encrypted_zipcode
-        t.string :mode
-      end
+  ActiveRecord::Schema.define(version: 1) do
+    create_table :people do |t|
+      t.string   :encrypted_email
+      t.string   :password
+      t.string   :encrypted_credentials
+      t.binary   :salt
+      t.binary   :key_iv
+      t.string   :encrypted_email_salt
+      t.string   :encrypted_credentials_salt
+      t.string   :encrypted_email_iv
+      t.string   :encrypted_credentials_iv
+    end
+    create_table :accounts do |t|
+      t.string :encrypted_password
+      t.string :encrypted_password_iv
+      t.string :encrypted_password_salt
+    end
+    create_table :users do |t|
+      t.string :login
+      t.string :encrypted_password
+      t.string :encrypted_password_iv
+      t.boolean :is_admin
+    end
+    create_table :prime_ministers do |t|
+      t.string :encrypted_name
+      t.string :encrypted_name_iv
+    end
+    create_table :addresses do |t|
+      t.binary :encrypted_street
+      t.binary :encrypted_street_iv
+      t.binary :encrypted_zipcode
+      t.string :mode
     end
   end
 end

--- a/test/compatibility_test.rb
+++ b/test/compatibility_test.rb
@@ -81,26 +81,24 @@ class CompatibilityTest < Minitest::Test
   private
 
   def create_tables
-    silence_stream(STDOUT) do
-      ActiveRecord::Schema.define(:version => 1) do
-        create_table :nonmarshalling_pets do |t|
-          t.string :name
-          t.string :encrypted_nickname
-          t.string :encrypted_nickname_iv
-          t.string :encrypted_nickname_salt
-          t.string :encrypted_birthdate
-          t.string :encrypted_birthdate_iv
-          t.string :encrypted_birthdate_salt
-        end
-        create_table :marshalling_pets do |t|
-          t.string :name
-          t.string :encrypted_nickname
-          t.string :encrypted_nickname_iv
-          t.string :encrypted_nickname_salt
-          t.string :encrypted_birthdate
-          t.string :encrypted_birthdate_iv
-          t.string :encrypted_birthdate_salt
-        end
+    ActiveRecord::Schema.define(:version => 1) do
+      create_table :nonmarshalling_pets do |t|
+        t.string :name
+        t.string :encrypted_nickname
+        t.string :encrypted_nickname_iv
+        t.string :encrypted_nickname_salt
+        t.string :encrypted_birthdate
+        t.string :encrypted_birthdate_iv
+        t.string :encrypted_birthdate_salt
+      end
+      create_table :marshalling_pets do |t|
+        t.string :name
+        t.string :encrypted_nickname
+        t.string :encrypted_nickname_iv
+        t.string :encrypted_nickname_salt
+        t.string :encrypted_birthdate
+        t.string :encrypted_birthdate_iv
+        t.string :encrypted_birthdate_salt
       end
     end
   end

--- a/test/legacy_active_record_test.rb
+++ b/test/legacy_active_record_test.rb
@@ -4,14 +4,12 @@ require_relative 'test_helper'
 ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => ':memory:'
 
 def create_people_table
-  silence_stream(STDOUT) do
-    ActiveRecord::Schema.define(:version => 1) do
-      create_table :legacy_people do |t|
-        t.string   :encrypted_email
-        t.string   :password
-        t.string   :encrypted_credentials
-        t.string   :salt
-      end
+  ActiveRecord::Schema.define(:version => 1) do
+    create_table :legacy_people do |t|
+      t.string   :encrypted_email
+      t.string   :password
+      t.string   :encrypted_credentials
+      t.string   :salt
     end
   end
 end

--- a/test/legacy_compatibility_test.rb
+++ b/test/legacy_compatibility_test.rb
@@ -73,20 +73,18 @@ class LegacyCompatibilityTest < Minitest::Test
   private
 
   def create_tables
-    silence_stream(STDOUT) do
-      ActiveRecord::Schema.define(:version => 1) do
-        create_table :legacy_nonmarshalling_pets do |t|
-          t.string :name
-          t.string :encrypted_nickname
-          t.string :encrypted_birthdate
-          t.string :salt
-        end
-        create_table :legacy_marshalling_pets do |t|
-          t.string :name
-          t.string :encrypted_nickname
-          t.string :encrypted_birthdate
-          t.string :salt
-        end
+    ActiveRecord::Schema.define(:version => 1) do
+      create_table :legacy_nonmarshalling_pets do |t|
+        t.string :name
+        t.string :encrypted_nickname
+        t.string :encrypted_birthdate
+        t.string :salt
+      end
+      create_table :legacy_marshalling_pets do |t|
+        t.string :name
+        t.string :encrypted_nickname
+        t.string :encrypted_birthdate
+        t.string :salt
       end
     end
   end


### PR DESCRIPTION
Rails 5 deprecated silence_stream due to it not being thread safe - this patch removes it from the test cases.  

The only change should be that running the tests is a little noisier..

