### PR TITLE
adding MIT license to gemspec

### DIFF
--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -14,9 +14,10 @@ Gem::Specification.new do |s|
   s.summary     = 'Encrypt and decrypt attributes'
   s.description = 'Generates attr_accessors that encrypt and decrypt attributes transparently'
 
-  s.authors   = ['Sean Huber', 'S. Brent Faulkner', 'William Monk', 'Stephen Aghaulor']
+  s.authors  = ['Sean Huber', 'S. Brent Faulkner', 'William Monk', 'Stephen Aghaulor']
   s.email    = ['seah@shuber.io', 'sbfaulkner@gmail.com', 'billy.monk@gmail.com', 'saghaulor@gmail.com']
   s.homepage = 'http://github.com/attr-encrypted/attr_encrypted'
+  s.license  = 'MIT'
 
   s.has_rdoc = false
   s.rdoc_options = ['--line-numbers', '--inline-source', '--main', 'README.rdoc']


### PR DESCRIPTION
Listing the license in the gemspec can be useful for other tools that read gem dependencies. 

More info at [Gemspec#license=](http://guides.rubygems.org/specification-reference/#license=)
