### PR TITLE
Allow marshaling objects not implementing #empty?

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -343,7 +343,7 @@ module AttrEncrypted
     #  @user.encrypt(:email, 'test@example.com')
     def encrypt(attribute, value)
       encrypted_attributes[attribute.to_sym][:operation] = :encrypting
-      encrypted_attributes[attribute.to_sym][:value_present] = (value && !value.empty?)
+      encrypted_attributes[attribute.to_sym][:value_present] = (value && (!value.respond_to?(:empty?) || !value.empty?))
       self.class.encrypt(attribute, value, evaluated_attr_encrypted_options_for(attribute))
     end
 

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -188,6 +188,12 @@ class AttrEncryptedTest < Minitest::Test
     refute_nil @user.encrypted_with_marshaling
   end
 
+  def test_should_encrypt_with_marshaling_even_complex_objects
+    @user = User.new
+    @user.with_marshaling = BigDecimal(123)
+    refute_nil @user.encrypted_with_marshaling
+  end
+
   def test_should_use_custom_encryptor_and_crypt_method_names_and_arguments
     assert_equal SillyEncryptor.silly_encrypt(:value => 'testing', :some_arg => 'test'), User.encrypt_credit_card('testing')
   end


### PR DESCRIPTION
Without this small change it is not possible to encrypt objects like BigDecimal or even ordinary numbers. Decrypting was already possible before (and there is also a test or two for this).