### PR TITLE
Fix evaluation of private options.

### DIFF
--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('simplecov-rcov')
-  s.add_development_dependency("codeclimate-test-reporter")
+  s.add_development_dependency("codeclimate-test-reporter", '<= 0.6.0')
 
   s.cert_chain  = ['certs/saghaulor.pem']
   s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/

--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -383,7 +383,7 @@ module AttrEncrypted
       #
       # If the option is not a symbol or proc then the original option is returned
       def evaluate_attr_encrypted_option(option)
-        if option.is_a?(Symbol) && respond_to?(option)
+        if option.is_a?(Symbol) && respond_to?(option, true)
           send(option)
         elsif option.respond_to?(:call)
           option.call(self)

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -41,6 +41,7 @@ class User
     self.should_encrypt = true
   end
 
+  private
   def secret_key
     SECRET_KEY
   end


### PR DESCRIPTION
- Previously we called respond_to? to verify that the object responded
to the method before sending it. However, it was implemented to preclude
protected and private methods.
- Fixes #242