### PR TITLE
Set ivar before encrypting

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -159,8 +159,8 @@ module AttrEncrypted
       end
 
       define_method("#{attribute}=") do |value|
-        send("#{encrypted_attribute_name}=", encrypt(attribute, value))
         instance_variable_set("@#{attribute}", value)
+        send("#{encrypted_attribute_name}=", encrypt(attribute, value))
       end
 
       define_method("#{attribute}?") do


### PR DESCRIPTION
Allows for reflection on value in deciding the IV... want non-repeating but deterministic IV, e.g. SHA of an email address, so same IV is never used twice but encrypted value can be calculated deterministically from unencrypted value, to support finding user by email or other find_or_create semantics.

If this effects return value and need to keep it with a tap something or there's another hook I'm not finding to allow the model to reflect on unencrypted value in determining IV, I'm open to that... I'd also like to backport this change to 1.4 if it's acceptable, as that's what we're currently trying to upgrade from and I think this may block us.