### PR TITLE
Adds usage for web forms to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ You can use a string or binary column type. (See the encode option section below
 
 By default, the encrypted attribute name is `encrypted_#{attribute}` (e.g. `attr_encrypted :email` would create an attribute named `encrypted_email`). So, if you're storing the encrypted attribute in the database, you need to make sure the `encrypted_#{attribute}` field exists in your table. You have a couple of options if you want to name your attribute or db column something else, see below for more details.
 
+### Using the encrypted attribute in a _form
+
+If you are going to encrypt data that is entered by a user in a form, you will need to specify the encrypted attribute in the label, but not in the form field, like so:
+
+```
+  <div class="field">
+    <%= f.label :name %><br>
+    <%= f.text_field :name %>
+  </div>
+  <div class="field">
+    <%= f.label :encrypted_ssn %><br>
+    <%= f.text_field :ssn %>
+  </div>
+```
 
 ## attr_encrypted options
 


### PR DESCRIPTION
Because there is a bit of a trick that is not obvious when it comes
to using the attribute in a web form, it is nice to have in the README.