### PR TITLE
Don't change iv field when value is the same

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -159,8 +159,11 @@ module AttrEncrypted
       end
 
       define_method("#{attribute}=") do |value|
-        send("#{encrypted_attribute_name}=", encrypt(attribute, value))
-        instance_variable_set("@#{attribute}", value)
+        old_value = instance_variable_get("@#{attribute}")
+        if old_value.nil? || old_value != value
+          send("#{encrypted_attribute_name}=", encrypt(attribute, value))
+          instance_variable_set("@#{attribute}", value)
+        end
       end
 
       define_method("#{attribute}?") do

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -463,4 +463,13 @@ class AttrEncryptedTest < Minitest::Test
     user.with_true_if = nil
     assert_nil user.encrypted_with_true_if_iv
   end
+
+  def test_should_not_generate_iv_if_same_value
+    user = User.new
+    assert_nil user.encrypted_email_iv
+    user.email = 'thing@thing.com'
+    refute_nil(old_value = user.encrypted_email_iv)
+    user.email = 'thing@thing.com'
+    assert_equal old_value, user.encrypted_email_iv
+  end
 end


### PR DESCRIPTION
```
user = User.new(name: 'hi')
user.name = 'hi'
```

That code would generate two different ivs.
At first look that is not an issue, but when using attr_encrypted combined
with ActiveRecord this could impose some issues. Like extra writes to the db.
Also, marking some attributes as dirty, when they were actually not changed.

[fixes #216]
also fixes https://stackoverflow.com/questions/47422328/attr-encrypted-updating-all-encrypted-fields-although-i-only-changed-one