### PR TITLE
Make sure object is a string before calling empty method

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -322,7 +322,7 @@ module AttrEncrypted
     #  @user.decrypt(:email, 'SOME_ENCRYPTED_EMAIL_STRING')
     def decrypt(attribute, encrypted_value)
       encrypted_attributes[attribute.to_sym][:operation] = :decrypting
-      encrypted_attributes[attribute.to_sym][:value_present] = (encrypted_value && !encrypted_value.empty?)
+      encrypted_attributes[attribute.to_sym][:value_present] = self.class.not_empty?(encrypted_value)
       self.class.decrypt(attribute, encrypted_value, evaluated_attr_encrypted_options_for(attribute))
     end
 
@@ -343,7 +343,7 @@ module AttrEncrypted
     #  @user.encrypt(:email, 'test@example.com')
     def encrypt(attribute, value)
       encrypted_attributes[attribute.to_sym][:operation] = :encrypting
-      encrypted_attributes[attribute.to_sym][:value_present] = (value && !value.empty?)
+      encrypted_attributes[attribute.to_sym][:value_present] = self.class.not_empty?(value)
       self.class.encrypt(attribute, value, evaluated_attr_encrypted_options_for(attribute))
     end
 

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -420,6 +420,9 @@ class AttrEncryptedTest < Minitest::Test
     user = User.new
     user.with_true_if = 'derp'
     refute_nil user.encrypted_with_true_if_iv
+
+    user.with_true_if = Object.new
+    refute_nil user.encrypted_with_true_if_iv
   end
 
   def test_should_not_generate_salt_for_attribute_when_if_option_is_false


### PR DESCRIPTION
This error was introduced in here https://github.com/attr-encrypted/attr_encrypted/commit/d0c1aa0105d17687fa8e5ced739a5b253776d73a 

I found it, when bumping the gem from version 3.0.3 to the master branch.

The issue here was that a non-string value would raise now, as it does not respond to the `empty?` method.