### PR TITLE
Fix superfluous definition of accessors

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -143,16 +143,19 @@ module AttrEncrypted
       encrypted_attribute_name = (options[:attribute] ? options[:attribute] : [options[:prefix], attribute, options[:suffix]].join).to_sym
 
       instance_methods_as_symbols = attribute_instance_methods_as_symbols
-      attr_reader encrypted_attribute_name unless instance_methods_as_symbols.include?(encrypted_attribute_name)
-      attr_writer encrypted_attribute_name unless instance_methods_as_symbols.include?(:"#{encrypted_attribute_name}=")
 
-      iv_name = "#{encrypted_attribute_name}_iv".to_sym
-      attr_reader iv_name unless instance_methods_as_symbols.include?(iv_name)
-      attr_writer iv_name unless instance_methods_as_symbols.include?(:"#{iv_name}=")
+      if attribute_instance_methods_as_symbols_available?
+        attr_reader encrypted_attribute_name unless instance_methods_as_symbols.include?(encrypted_attribute_name)
+        attr_writer encrypted_attribute_name unless instance_methods_as_symbols.include?(:"#{encrypted_attribute_name}=")
 
-      salt_name = "#{encrypted_attribute_name}_salt".to_sym
-      attr_reader salt_name unless instance_methods_as_symbols.include?(salt_name)
-      attr_writer salt_name unless instance_methods_as_symbols.include?(:"#{salt_name}=")
+        iv_name = "#{encrypted_attribute_name}_iv".to_sym
+        attr_reader iv_name unless instance_methods_as_symbols.include?(iv_name)
+        attr_writer iv_name unless instance_methods_as_symbols.include?(:"#{iv_name}=")
+
+        salt_name = "#{encrypted_attribute_name}_salt".to_sym
+        attr_reader salt_name unless instance_methods_as_symbols.include?(salt_name)
+        attr_writer salt_name unless instance_methods_as_symbols.include?(:"#{salt_name}=")
+      end
 
       define_method(attribute) do
         instance_variable_get("@#{attribute}") || instance_variable_set("@#{attribute}", decrypt(attribute, send(encrypted_attribute_name)))
@@ -446,6 +449,10 @@ module AttrEncrypted
 
   def attribute_instance_methods_as_symbols
     instance_methods.collect { |method| method.to_sym }
+  end
+
+  def attribute_instance_methods_as_symbols_available?
+    true
   end
 
 end

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -88,14 +88,15 @@ if defined?(ActiveRecord::Base)
             # methods returned to let ActiveRecord define the accessor methods
             # for the db columns
 
-            # Use with_connection so the connection doesn't stay pinned to the thread.
-            connected = ::ActiveRecord::Base.connection_pool.with_connection(&:active?) rescue false
-
-            if connected && table_exists?
+            if connected? && table_exists?
               columns_hash.keys.inject(super) {|instance_methods, column_name| instance_methods.concat [column_name.to_sym, :"#{column_name}="]}
             else
               super
             end
+          end
+
+          def attribute_instance_methods_as_symbols_available?
+            connected? && table_exists?
           end
 
           # Allows you to use dynamic methods like <tt>find_by_email</tt> or <tt>scoped_by_email</tt> for

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -41,9 +41,6 @@ def create_tables
   end
 end
 
-# The table needs to exist before defining the class
-create_tables
-
 ActiveRecord::MissingAttributeError = ActiveModel::MissingAttributeError unless defined?(ActiveRecord::MissingAttributeError)
 
 if ::ActiveRecord::VERSION::STRING > "4.0"
@@ -333,7 +330,9 @@ class ActiveRecordTest < Minitest::Test
   def test_should_evaluate_proc_based_mode
     street = '123 Elm'
     zipcode = '12345'
-    address = Address.new(street: street, zipcode: zipcode, mode: :single_iv_and_salt)
-    assert_nil address.encrypted_zipcode_iv
+    address = Address.create(street: street, zipcode: zipcode, mode: :single_iv_and_salt)
+    address.reload
+    refute_equal address.encrypted_zipcode, zipcode
+    assert_equal address.zipcode, zipcode
   end
 end


### PR DESCRIPTION
Per @nagachika

 Don't define unnecessary accessors with ActiveRecord Adapter.
    Without DB connection, ActiveRecord doesn't define methods for columns
    and AttrEncrypted define attr_reader and attr_writer for the encrypted
    columns.
    As a result, AR model with attr_encrypted column return nil for the
    target column if the DB connection was lost at the load time.

    To suppress this behavior, don't define accessors if DB connection was
    active.
    Introduce attribute_instance_methods_as_symbols_available? to detect
    connection failure with ActiveRecord Adapter.
 
Per @saghaulor

Removed extra test setup from ActiveRecord adapter tests

    - The extra db setup was hiding the fact that accessors were being defined superfluously.
    - They also allowed for a test to be written incorrectly based on this incorrect
      behavior. Consequently, the test required rewriting. The rewritten test now
      better reflects the intended nature of the test.
