### PR TITLE
 Optional update encrypted attributes only when values changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ The following are the default options used by `attr_encrypted`:
   decrypt_method:    'decrypt',
   mode:              :per_attribute_iv,
   algorithm:         'aes-256-gcm',
-  allow_empty_value: false
+  allow_empty_value: false,
+  update_unchanged:  true
 ```
 
 All of the aforementioned options are explained in depth below.
@@ -319,6 +320,16 @@ You may want to encrypt empty strings or nil so as to not reveal which records a
 ```ruby
   class User
     attr_encrypted :credentials, key: 'some secret key', marshal: true, allow_empty_value: true
+  end
+```
+
+### The `:update_unchanged` option
+
+You may want to only update changed attributes each time the record is saved.
+
+```ruby
+  class User
+    attr_encrypted :email, key: 'some secret key', marshal: true, update_unchanged: false
   end
 ```
 

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -466,4 +466,43 @@ class AttrEncryptedTest < Minitest::Test
     user.with_true_if = nil
     assert_nil user.encrypted_with_true_if_iv
   end
+
+  def test_should_not_generate_iv_if_same_value_when_option_is_false
+    user = User.new
+    User.encrypted_attributes[:email][:update_unchanged] = false
+    assert_nil user.encrypted_email_iv
+    user.email = 'thing@thing.com'
+    refute_nil(old_value = user.encrypted_email_iv)
+    user.email = 'thing@thing.com'
+    assert_equal old_value, user.encrypted_email_iv
+  end
+
+  def test_should_generate_iv_if_same_value_when_option_is_true
+    user = User.new
+    User.encrypted_attributes[:email][:update_unchanged] = true
+    assert_nil user.encrypted_email_iv
+    user.email = 'thing@thing.com'
+    refute_nil(old_value = user.encrypted_email_iv)
+    user.email = 'thing@thing.com'
+    refute_equal old_value, user.encrypted_email_iv
+  end
+
+  def test_should_not_update_iv_if_same_value_when_option_is_false
+    user = User.new(email: 'thing@thing.com')
+    User.encrypted_attributes[:email][:update_unchanged] = false
+    old_encrypted_email_iv = user.encrypted_email_iv
+    refute_nil old_encrypted_email_iv
+    user.email = 'thing@thing.com'
+    assert_equal old_encrypted_email_iv, user.encrypted_email_iv
+  end
+
+  def test_should_not_update_iv_if_same_value_when_option_is_true
+    user = User.new(email: 'thing@thing.com')
+    User.encrypted_attributes[:email][:update_unchanged] = true
+    old_encrypted_email_iv = user.encrypted_email_iv
+    refute_nil old_encrypted_email_iv
+    user.email = 'thing@thing.com'
+    refute_nil user.encrypted_email_iv
+    refute_equal old_encrypted_email_iv, user.encrypted_email_iv
+  end
 end


### PR DESCRIPTION
Currently all encrypted attributes are updated each time the record is saved. This means that also unchanges values are encrypted again. When creating an audit log for changed attributes this is unwanted behaviour. 

This pull request makes it is possible to change this default behaviour and encrypt only the changed attributes again.