### PR TITLE
 Test against ActiveRecord 5.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ matrix:
       env: ACTIVERECORD=5.2.0
   allow_failures:
     - rvm: rbx
+    - env: ACTIVERECORD=5.2.0
   fast_finish: true
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,21 @@ env:
   - ACTIVERECORD=4.2.0
   - ACTIVERECORD=5.0.0
   - ACTIVERECORD=5.1.1
+  - ACTIVERECORD=5.2.0
 matrix:
   exclude:
     - rvm: 2.0
       env: ACTIVERECORD=5.0.0
     - rvm: 2.0
       env: ACTIVERECORD=5.1.1
+    - rvm: 2.0
+      env: ACTIVERECORD=5.2.0
     - rvm: 2.1
       env: ACTIVERECORD=5.0.0
     - rvm: 2.1
       env: ACTIVERECORD=5.1.1
+    - rvm: 2.1
+      env: ACTIVERECORD=5.2.0
     - rvm: 2.4.0
       env: ACTIVERECORD=3.0.0
     - rvm: 2.4.0
@@ -52,6 +57,8 @@ matrix:
       env: ACTIVERECORD=5.0.0
     - rvm: rbx
       env: ACTIVERECORD=5.1.1
+    - rvm: rbx
+      env: ACTIVERECORD=5.2.0
   allow_failures:
     - rvm: rbx
   fast_finish: true


### PR DESCRIPTION
Add AR 5.2.0 to build matrix.

But these builds are failing due to AR::Dirty changes.