### PR TITLE
Only load key if needed

### DIFF
--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -478,4 +478,13 @@ class AttrEncryptedTest < Minitest::Test
     assert_equal :encrypting, user.encrypted_attributes[:ssn][:operation]
     assert_nil another_user.encrypted_attributes[:ssn][:operation]
   end
+
+  def test_should_not_by_default_generate_key_when_attribute_is_empty
+    user = User.new
+    calls = 0
+    user.stub(:secret_key, lambda { calls += 1; SECRET_KEY }) do
+      user.ssn
+    end
+    assert_equal 0, calls
+  end
 end


### PR DESCRIPTION
Hey @saghaulor, big thanks for all the work you do on this 👍 

Currently, encryption keys are sometimes loaded when they aren't needed. For instance, the code below prints `Loaded`, even though email is empty.

```ruby
class User
  extend AttrEncrypted
  attr_accessor :email

  attr_encrypted :email, key: :encryption_key

  def encryption_key
    puts "Loaded"
    "This is a key that is 256 bits!!"
  end
end

User.new.email
```

This can cause issues when generating encryption keys on the fly (see https://github.com/ankane/kms_encrypted/issues/3 for an example).

This PR fixes it.