### PR TITLE
Fix for the frozen string error

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -242,7 +242,7 @@ module AttrEncrypted
         value = options[:marshaler].send(options[:load_method], value)
       elsif defined?(Encoding)
         encoding = Encoding.default_internal || Encoding.default_external
-        value = value.force_encoding(encoding.name)
+        value = value.dup.force_encoding(encoding.name)
       end
       value
     else


### PR DESCRIPTION
This PR fixes the exception about unable to modify frozen string when using attr_encrypted in a class that has the magic comment "# frozen_string_literal: true"