### PR TITLE
Fix random OpenSSL::Cipher::CipherErrors/iv argument errors

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -354,7 +354,11 @@ module AttrEncrypted
     # and their corresponding options as values to the instance
     #
     def encrypted_attributes
-      @encrypted_attributes ||= self.class.encrypted_attributes.dup
+      @encrypted_attributes ||= begin
+        duplicated= {}
+        self.class.encrypted_attributes.map { |key, value| duplicated[key] = value.dup }
+        duplicated
+      end
     end
 
     protected

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -466,4 +466,14 @@ class AttrEncryptedTest < Minitest::Test
     user.with_true_if = nil
     assert_nil user.encrypted_with_true_if_iv
   end
+
+  def test_encrypted_attributes_state_is_not_shared
+    user = User.new
+    user.ssn = '123456789'
+
+    another_user = User.new
+
+    assert_equal :encrypting, user.encrypted_attributes[:ssn][:operation]
+    assert_nil another_user.encrypted_attributes[:ssn][:operation]
+  end
 end


### PR DESCRIPTION
This fixes defect in which encrypted_attributes state is shared across all instances due to shallow copy which causes random OpenSSL::Cipher::CipherErrors  or iv argument errors during concurrent encrypts/decrypts under load.

An example (might need to increase thread count to replicate):
```
def concurrent_test(threads = 5)
  threads.times do
    Thread.new do
      begin
        2000.times do
          customer = Customer.new
          customer.ssn = '123456789'
          other_customer = Customer.new(encrypted_ssn: customer.encrypted_ssn, encrypted_ssn_iv: customer.encrypted_ssn_iv)
          customer.ssn = '555006666'
          other_customer.ssn
        end
      rescue => e
        puts "ERROR: #{e.inspect}"
      end
    end
  end
end
```

