### PR TITLE
Use a lazy load hook to configure Active Record

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -134,6 +134,8 @@ if defined?(ActiveRecord::Base)
     end
   end
 
-  ActiveRecord::Base.extend AttrEncrypted
-  ActiveRecord::Base.extend AttrEncrypted::Adapters::ActiveRecord
+  ActiveSupport.on_load(:active_record) do
+    extend AttrEncrypted
+    extend AttrEncrypted::Adapters::ActiveRecord
+  end
 end


### PR DESCRIPTION
Rails provides hooks to configure its core classes without loading them:

https://api.rubyonrails.org/v5.2.0/classes/ActiveSupport/LazyLoadHooks.html

Referencing `ActiveRecord::Base` directly was forcing it to load before the application had finished initializing, which can cause configuration to be applied incorrectly (e.g. https://github.com/rails/rails/issues/27276).