### PR TITLE
Can handle attr_encrypted :foo, :bar properly

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -52,37 +52,38 @@ if defined?(ActiveRecord::Base)
           def attr_encrypted(*attrs)
             super
             options = attrs.extract_options!
-            attr = attrs.pop
-            attribute attr if ::ActiveRecord::VERSION::STRING >= "5.1.0"
-            options.merge! encrypted_attributes[attr]
+            attrs.each do |attr|
+              attribute attr if ::ActiveRecord::VERSION::STRING >= "5.1.0"
+              options.merge! encrypted_attributes[attr]
 
-            define_method("#{attr}_was") do
-              attribute_was(attr)
-            end
-
-            if ::ActiveRecord::VERSION::STRING >= "4.1"
-              define_method("#{attr}_changed?") do |options = {}|
-                attribute_changed?(attr, options)
+              define_method("#{attr}_was") do
+                attribute_was(attr)
               end
-            else
-              define_method("#{attr}_changed?") do
-                  attribute_changed?(attr)
+
+              if ::ActiveRecord::VERSION::STRING >= "4.1"
+                define_method("#{attr}_changed?") do |options = {}|
+                  attribute_changed?(attr, options)
+                end
+              else
+                define_method("#{attr}_changed?") do
+                    attribute_changed?(attr)
+                end
               end
+
+              define_method("#{attr}_change") do
+                attribute_change(attr)
+              end
+
+              define_method("#{attr}_with_dirtiness=") do |value|
+                attribute_will_change!(attr) if value != __send__(attr)
+                __send__("#{attr}_without_dirtiness=", value)
+              end
+
+              alias_method "#{attr}_without_dirtiness=", "#{attr}="
+              alias_method "#{attr}=", "#{attr}_with_dirtiness="
+
+              alias_method "#{attr}_before_type_cast", attr
             end
-
-            define_method("#{attr}_change") do
-              attribute_change(attr)
-            end
-
-            define_method("#{attr}_with_dirtiness=") do |value|
-              attribute_will_change!(attr) if value != __send__(attr)
-              __send__("#{attr}_without_dirtiness=", value)
-            end
-
-            alias_method "#{attr}_without_dirtiness=", "#{attr}="
-            alias_method "#{attr}=", "#{attr}_with_dirtiness="
-
-            alias_method "#{attr}_before_type_cast", attr
           end
 
           def attribute_instance_methods_as_symbols

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -114,6 +114,11 @@ class PersonUsingAlias < ActiveRecord::Base
   attr_encryptor :email, key: SECRET_KEY
 end
 
+class PersonWithListedAttributes < ActiveRecord::Base
+  self.table_name = 'people'
+  attr_encrypted :email, :credentials
+end
+
 class PrimeMinister < ActiveRecord::Base
   attr_encrypted :name, marshal: true, key: SECRET_KEY
 end
@@ -219,6 +224,12 @@ class ActiveRecordTest < Minitest::Test
     account.reload
     assert_equal Account::ACCOUNT_ENCRYPTION_KEY, account.key
     assert_equal pw.reverse, account.password
+  end
+
+  def test_should_handle_multiple_attributes_as_a_list
+    person = PersonWithListedAttributes.new
+    assert person.respond_to?(:email_changed?)
+    assert person.respond_to?(:credentials_changed?)
   end
 
   if ::ActiveRecord::VERSION::STRING > "4.0"


### PR DESCRIPTION
Currently `attr_encrypted :foo, :bar` will not create Dirty helper methods for `:foo` attribute because it doesn't handle lists.

This is just a change from `attr = attrs.pop` to `attrs.each do |attr|`