### PR TITLE
Adds caveat to allow_empty_value option usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ You may want to encrypt empty strings or nil so as to not reveal which records a
   end
 ```
 
+**Caveat:** The default encryptor doesn't support this option. Doing so will throw an error:
+```
+ArgumentError: data must not be empty
+```
+
+Make sure that your encryptor supports encryption of empty values when setting this to true.
 
 ## ORMs
 


### PR DESCRIPTION
Using allow_empty_value option with the default `Encryptor` does not work. It throws:
```
ArgumentError: data must not be empty
```

Please see:
https://github.com/ruby/openssl/blob/18ec883d6daaedbf32c66ca4ae6e41b66d0eeca4/ext/openssl/ossl_cipher.c#L389