### PR TITLE
Handle encoding frozen strings

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -241,12 +241,13 @@ module AttrEncrypted
       encrypted_value = encrypted_value.unpack(options[:encode]).first if options[:encode]
       value = options[:encryptor].send(options[:decrypt_method], options.merge!(value: encrypted_value))
       if options[:marshal]
-        value = options[:marshaler].send(options[:load_method], value)
+        options[:marshaler].send(options[:load_method], value)
       elsif defined?(Encoding)
         encoding = Encoding.default_internal || Encoding.default_external
-        value = value.force_encoding(encoding.name)
+        value.encode(encoding.name).freeze
+      else
+        value
       end
-      value
     else
       encrypted_value
     end

--- a/test/attr_encrypted_test.rb
+++ b/test/attr_encrypted_test.rb
@@ -374,6 +374,12 @@ class AttrEncryptedTest < Minitest::Test
     assert_nil thing.encrypted_email_salt
   end
 
+  def test_should_decrypt_and_encode_frozen_strings
+    email = 'hello@example.com'.encode(Encoding::EUC_JP).freeze
+    @user = User.new(email: email)
+    assert_equal email, @user.decrypt(:email, @user.encrypted_email)
+  end
+
   def test_should_decrypt_second_record
     @user1 = User.new
     @user1.email = 'test@example.com'


### PR DESCRIPTION
See #312

I couldn't figure out how to stub `defined?(Encoding)` for coverage... sorry. Seems like that's standard Ruby? I did some googling but couldn't find an answer