### PR TITLE
Do Gem::Version.new comparisons instead of string comparisons.

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -32,7 +32,7 @@ if defined?(ActiveRecord::Base)
             end
             private :perform_attribute_assignment
 
-            if ::ActiveRecord::VERSION::STRING > "3.1"
+            if Gem::Version.new(::ActiveRecord::VERSION::STRING) > Gem::Version.new("3.1")
               alias_method :assign_attributes_without_attr_encrypted, :assign_attributes
               def assign_attributes(*args)
                 perform_attribute_assignment :assign_attributes_without_attr_encrypted, *args
@@ -53,14 +53,14 @@ if defined?(ActiveRecord::Base)
             super
             options = attrs.extract_options!
             attr = attrs.pop
-            attribute attr if ::ActiveRecord::VERSION::STRING >= "5.1.0"
+            attribute attr if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new("5.1.0")
             options.merge! encrypted_attributes[attr]
 
             define_method("#{attr}_was") do
               attribute_was(attr)
             end
 
-            if ::ActiveRecord::VERSION::STRING >= "4.1"
+            if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new("4.1")
               define_method("#{attr}_changed?") do |options = {}|
                 attribute_changed?(attr, options)
               end

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -45,7 +45,7 @@ end
 
 ActiveRecord::MissingAttributeError = ActiveModel::MissingAttributeError unless defined?(ActiveRecord::MissingAttributeError)
 
-if ::ActiveRecord::VERSION::STRING > "4.0"
+if Gem::Version.new(::ActiveRecord::VERSION::STRING) > Gem::Version.new("4.0")
   module Rack
     module Test
       class UploadedFile; end
@@ -106,7 +106,7 @@ end
 class UserWithProtectedAttribute < ActiveRecord::Base
   self.table_name = 'users'
   attr_encrypted :password, key: SECRET_KEY
-  attr_protected :is_admin if ::ActiveRecord::VERSION::STRING < "4.0"
+  attr_protected :is_admin if Gem::Version.new(::ActiveRecord::VERSION::STRING) < Gem::Version.new("4.0")
 end
 
 class PersonUsingAlias < ActiveRecord::Base
@@ -221,7 +221,7 @@ class ActiveRecordTest < Minitest::Test
     assert_equal pw.reverse, account.password
   end
 
-  if ::ActiveRecord::VERSION::STRING > "4.0"
+  if Gem::Version.new(::ActiveRecord::VERSION::STRING) > Gem::Version.new("4.0")
     def test_should_assign_attributes
       @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
       @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true).permit(:login)
@@ -261,7 +261,7 @@ class ActiveRecordTest < Minitest::Test
 
     def test_should_assign_protected_attributes
       @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      if ::ActiveRecord::VERSION::STRING > "3.1"
+      if Gem::Version.new(::ActiveRecord::VERSION::STRING) > Gem::Version.new("3.1")
         @user.send(:assign_attributes, { login: 'modified', is_admin: true }, without_protection: true)
       else
         @user.send(:attributes=, { login: 'modified', is_admin: true }, false)
@@ -291,7 +291,7 @@ class ActiveRecordTest < Minitest::Test
     assert_nil @person.encrypted_credentials_iv
   end
 
-  if ::ActiveRecord::VERSION::STRING > "3.1"
+  if Gem::Version.new(::ActiveRecord::VERSION::STRING) > Gem::Version.new("3.1")
     def test_should_allow_assign_attributes_with_nil
       @person = Person.new
       assert_nil(@person.assign_attributes nil)


### PR DESCRIPTION
Fixes #380

In a number of cases, we do string comparisons to check versions. For example, in [https://github.com/attr-encrypted/attr_encrypted/blob/a96693e9a2a25f4f910bf915e29b0f364f277032/lib/attr_encrypted/adapters/active_record.rb#L56), we do this:
```
attribute attr if ::ActiveRecord::VERSION::STRING >= "5.1.0"
```

This may fail. For example, if `::ActiveRecord::VERSION::STRING` is `10.0.0`, this string comparison is `false` (but we expect it to be true).
