### PR TITLE
Add support for Ruby 2.7 and its kwargs

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -61,7 +61,7 @@ if defined?(ActiveRecord::Base)
             end
 
             define_method("#{attr}_changed?") do |options = {}|
-              attribute_changed?(attr, options)
+              attribute_changed?(attr, **options)
             end
 
             define_method("#{attr}_change") do


### PR DESCRIPTION
In Ruby 3.0, positional arguments and keyword arguments will be separated. Ruby 2.7 will warn for behaviors that will change in Ruby 3.0.