### PR TITLE
Change update behavior of active record to default when assigning nil values

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -25,7 +25,9 @@ if defined?(ActiveRecord::Base)
             end
 
             def perform_attribute_assignment(method, new_attributes, *args)
-              return if new_attributes.blank?
+              if !new_attributes.respond_to?(:stringify_keys)
+                raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
+              end
 
               send method, new_attributes.reject { |k, _|  self.class.encrypted_attributes.key?(k.to_sym) }, *args
               send method, new_attributes.reject { |k, _| !self.class.encrypted_attributes.key?(k.to_sym) }, *args

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -270,9 +270,12 @@ class ActiveRecordTest < Minitest::Test
     end
   end
 
-  def test_should_allow_assignment_of_nil_attributes
+  # Default active record behavior is to raise error when assignment nil
+  def test_should_raise_error_when_assigning_nil_to_attributes
     @person = Person.new
-    assert_nil(@person.attributes = nil)
+    assert_raises ArgumentError do
+      @person.attributes = nil
+    end
   end
 
   def test_should_allow_proc_based_mode
@@ -292,9 +295,11 @@ class ActiveRecordTest < Minitest::Test
   end
 
   if ::ActiveRecord::VERSION::STRING > "3.1"
-    def test_should_allow_assign_attributes_with_nil
+    def test_should_raise_error_when_assign_attributes_with_nil
       @person = Person.new
-      assert_nil(@person.assign_attributes nil)
+      assert_raises ArgumentError do
+        @person.assign_attributes nil
+      end
     end
   end
 


### PR DESCRIPTION
Hi,
I'm making this PR because in my work we descover that when updating active record instances with nil it does not return an error, but without this library it does, so one of our test was failing. Investigating this problem Active Record have a check that this library does not have so in this PR I added that.
Example:
```
# With this library
record.update(nil) # => true

# Without this library
record.update(nil) # => ArgumentError: when assign.....

```
Is this behavior intended? only two test were falling with this change and I modified them (two other test were failing even without the changes so I ignore them)
Thanks for this library.