### PR TITLE
[WIP] Convert to GitHub Actions - Test Modern Ruby and ActiveRecord Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: ['2.7', '3.0', '3.1']
+        activerecord: [6.1, 7.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        cache-version: 1
     - run: bundle exec rake
       env:
         ACTIVERECORD: ${{ matrix.activerecord }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ jobs:
         ruby: ['2.7', '3.0', '3.1']
         activerecord: [6.1, 7.0]
     runs-on: ${{ matrix.os }}
+    env:
+      ACTIVERECORD: ${{ matrix.activerecord }}
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -17,5 +19,3 @@ jobs:
         bundler-cache: true
         cache-version: 1
     - run: bundle exec rake
-      env:
-        ACTIVERECORD: ${{ matrix.activerecord }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,3 +16,5 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rake
+      env:
+        ACTIVERECORD: ${{ matrix.activerecord }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [push]
 jobs:
   test:
     strategy:


### PR DESCRIPTION
This is a sample of using the existing test configuration with modern Ruby and ActiveRecord versions. Long term we would probably want to switch to Appraisal and stop stuffing the ActiveRecord version conditionally in the `.gemspec`. This is just to show an example of an alternative should Travis not re-activate the organization with credits.