### PR TITLE
[WIP] Sample of converting existing Travis config as-is to GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,54 @@
+name: CI
+on: [push]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: ['2.0', '2.1', '2.2.2', '2.3.0', '2.4.0', '2.5.0', 'rbx']
+        activerecord: [3.0.0, 3.1.0, 3.2.0, 4.0.0, 4.1.0, 4.2.0, 5.0.0, 5.1.1]
+        exclude:
+          - ruby: 2.0
+            activerecord: 5.0.0
+          - ruby: 2.0
+            activerecord: 5.1.1
+          - ruby: 2.1
+            activerecord: 5.0.0
+          - ruby: 2.1
+            activerecord: 5.1.1
+          - ruby: 2.4.0
+            activerecord: 3.0.0
+          - ruby: 2.4.0
+            activerecord: 3.1.0
+          - ruby: 2.4.0
+            activerecord: 3.2.0
+          - ruby: 2.4.0
+            activerecord: 4.0.0
+          - ruby: 2.4.0
+            activerecord: 4.1.0
+          - ruby: 2.5.0
+            activerecord: 3.0.0
+          - ruby: 2.5.0
+            activerecord: 3.1.0
+          - ruby: 2.5.0
+            activerecord: 3.2.0
+          - ruby: 2.5.0
+            activerecord: 4.0.0
+          - ruby: 2.5.0
+            activerecord: 4.1.0
+          - ruby: rbx
+            activerecord: 5.0.0
+          - ruby: rbx
+            activerecord: 5.1.1
+    runs-on: ${{ matrix.os }}
+    env:
+      ACTIVERECORD: ${{ matrix.activerecord }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+        cache-version: 1
+    - run: bundle exec rake


### PR DESCRIPTION
This is an example of adopting GitHub actions using the existing matrix configuration that is configured for Travis. However, I would advocate for us to begin dropping testing these very old versions, as shown in https://github.com/attr-encrypted/attr_encrypted/pull/414