### PR TITLE
Modern Ruby + ActiveRecord, Update Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.6.10
   - 2.7.6
 env:
+  - ACTIVERECORD=5.1.1
   - ACTIVERECORD=5.2.8
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
 dist: focal
+os: linux
 cache: bundler
 rvm:
   - 2.5.9
   - 2.6.10
   - 2.7.6
-  - 3.0.4
-  - 3.1.2
 env:
+  - ACTIVERECORD=5.0.0
+  - ACTIVERECORD=5.1.1
   - ACTIVERECORD=5.2.8
   - ACTIVERECORD=6.0.6
   - ACTIVERECORD=6.1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-os: focal
 dist: bionic
 cache: bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: bundler
 rvm:
   - 2.5.9
   - 2.6.10
-  - 2.7
-  - 3.0
-  - 3.1
+  - 2.7.6
+  - 3.0.4
+  - 3.1.2
 env:
   - ACTIVERECORD=5.2.8
   - ACTIVERECORD=6.0.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
-dist: bionic
+dist: focal
 cache: bundler
 rvm:
   - 2.5.9
   - 2.6.10
-  - 2.7.6
-  - 3.0.4
-  - 3.1.2
+  - 2.7
+  - 3.0
+  - 3.1
 env:
   - ACTIVERECORD=5.2.8
   - ACTIVERECORD=6.0.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   - ACTIVERECORD=5.0.0
   - ACTIVERECORD=5.1.1
   - ACTIVERECORD=5.2.8
-  - ACTIVERECORD=6.0.6
-  - ACTIVERECORD=6.1.7
 jobs:
   fast_finish: true
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ dist: focal
 os: linux
 cache: bundler
 rvm:
-  - 2.5.9
   - 2.6.10
   - 2.7.6
 env:
-  - ACTIVERECORD=5.0.0
-  - ACTIVERECORD=5.1.1
   - ACTIVERECORD=5.2.8
 jobs:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,18 @@
-sudo: false
 language: ruby
+os: focal
+dist: bionic
 cache: bundler
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2.2
-  - 2.3.0
-  - 2.4.0
-  - 2.5.0
-  - rbx
+  - 2.5.9
+  - 2.6.10
+  - 2.7.6
+  - 3.0.4
+  - 3.1.2
 env:
-  - ACTIVERECORD=3.0.0
-  - ACTIVERECORD=3.1.0
-  - ACTIVERECORD=3.2.0
-  - ACTIVERECORD=4.0.0
-  - ACTIVERECORD=4.1.0
-  - ACTIVERECORD=4.2.0
-  - ACTIVERECORD=5.0.0
-  - ACTIVERECORD=5.1.1
-matrix:
-  exclude:
-    - rvm: 2.0
-      env: ACTIVERECORD=5.0.0
-    - rvm: 2.0
-      env: ACTIVERECORD=5.1.1
-    - rvm: 2.1
-      env: ACTIVERECORD=5.0.0
-    - rvm: 2.1
-      env: ACTIVERECORD=5.1.1
-    - rvm: 2.4.0
-      env: ACTIVERECORD=3.0.0
-    - rvm: 2.4.0
-      env: ACTIVERECORD=3.1.0
-    - rvm: 2.4.0
-      env: ACTIVERECORD=3.2.0
-    - rvm: 2.4.0
-      env: ACTIVERECORD=4.0.0
-    - rvm: 2.4.0
-      env: ACTIVERECORD=4.1.0
-    - rvm: 2.5.0
-      env: ACTIVERECORD=3.0.0
-    - rvm: 2.5.0
-      env: ACTIVERECORD=3.1.0
-    - rvm: 2.5.0
-      env: ACTIVERECORD=3.2.0
-    - rvm: 2.5.0
-      env: ACTIVERECORD=4.0.0
-    - rvm: 2.5.0
-      env: ACTIVERECORD=4.1.0
-    - rvm: rbx
-      env: ACTIVERECORD=5.0.0
-    - rvm: rbx
-      env: ACTIVERECORD=5.1.1
-  allow_failures:
-    - rvm: rbx
+  - ACTIVERECORD=5.2.8
+  - ACTIVERECORD=6.0.6
+  - ACTIVERECORD=6.1.7
+jobs:
   fast_finish: true
 addons:
   code_climate:

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency('activerecord-jdbcsqlite3-adapter')
     s.add_development_dependency('jdbc-sqlite3', '< 3.8.7') # 3.8.7 is nice and broke
   else
-    s.add_development_dependency('sqlite3', '< 1.5.0') # 1.5 and up requires Ruby 2.6 or greater
+    s.add_development_dependency('sqlite3')
   end
   s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('simplecov')

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -19,15 +19,12 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/attr-encrypted/attr_encrypted'
   s.license = 'MIT'
 
-  s.has_rdoc = false
-  s.rdoc_options = ['--line-numbers', '--inline-source', '--main', 'README.rdoc']
-
   s.require_paths = ['lib']
 
   s.files      = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- test/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.add_dependency('encryptor', ['~> 3.0.0'])
   # support for testing with specific active record version
@@ -42,10 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest')
   s.add_development_dependency('sequel')
-  if RUBY_VERSION < '2.1.0'
-    s.add_development_dependency('nokogiri', '< 1.7.0')
-    s.add_development_dependency('public_suffix', '< 3.0.0')
-  end
   if defined?(RUBY_ENGINE) && RUBY_ENGINE.to_sym == :jruby
     s.add_development_dependency('activerecord-jdbcsqlite3-adapter')
     s.add_development_dependency('jdbc-sqlite3', '< 3.8.7') # 3.8.7 is nice and broke
@@ -53,6 +46,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency('sqlite3')
   end
   s.add_development_dependency('dm-sqlite-adapter')
+  s.add_development_dependency('pry')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('simplecov-rcov')
 

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -55,7 +55,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('simplecov-rcov')
-  s.add_development_dependency("codeclimate-test-reporter", '<= 0.6.0')
 
   s.cert_chain  = ['certs/saghaulor.pem']
   s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem") if $0 =~ /gem\z/

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency('activerecord-jdbcsqlite3-adapter')
     s.add_development_dependency('jdbc-sqlite3', '< 3.8.7') # 3.8.7 is nice and broke
   else
-    s.add_development_dependency('sqlite3')
+    s.add_development_dependency('sqlite3', '< 1.5.0') # 1.5 and up requires Ruby 2.6 or greater
   end
   s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('simplecov')

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -45,15 +45,13 @@ end
 
 ActiveRecord::MissingAttributeError = ActiveModel::MissingAttributeError unless defined?(ActiveRecord::MissingAttributeError)
 
-if ::ActiveRecord::VERSION::STRING > "4.0"
-  module Rack
-    module Test
-      class UploadedFile; end
-    end
+module Rack
+  module Test
+    class UploadedFile; end
   end
-
-  require 'action_controller/metal/strong_parameters'
 end
+
+require 'action_controller/metal/strong_parameters'
 
 class Person < ActiveRecord::Base
   self.attr_encrypted_options[:mode] = :per_attribute_iv_and_salt
@@ -106,7 +104,6 @@ end
 class UserWithProtectedAttribute < ActiveRecord::Base
   self.table_name = 'users'
   attr_encrypted :password, key: SECRET_KEY
-  attr_protected :is_admin if ::ActiveRecord::VERSION::STRING < "4.0"
 end
 
 class PersonUsingAlias < ActiveRecord::Base
@@ -221,52 +218,53 @@ class ActiveRecordTest < Minitest::Test
     assert_equal pw.reverse, account.password
   end
 
-  if ::ActiveRecord::VERSION::STRING > "4.0"
-    def test_should_assign_attributes
-      @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true).permit(:login)
-      assert_equal 'modified', @user.login
+  if ::ActiveRecord::VERSION::STRING >= "5.2"
+    def test_should_create_will_save_change_to_predicate
+      person = Person.create!(email: 'test@example.com')
+      refute person.will_save_change_to_email?
+      person.email = 'test@example.com'
+      refute person.will_save_change_to_email?
+      person.email = 'test2@example.com'
+      assert person.will_save_change_to_email?
     end
 
-    def test_should_not_assign_protected_attributes
-      @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true).permit(:login)
-      assert !@user.is_admin?
+    def test_should_create_saved_change_to_predicate
+      person = Person.create!(email: 'test@example.com')
+      assert person.saved_change_to_email?
+      person.reload
+      person.email = 'test@example.com'
+      refute person.saved_change_to_email?
+      person.email = nil
+      refute person.saved_change_to_email?
+      person.email = 'test2@example.com'
+      refute person.saved_change_to_email?
+      person.save
+      assert person.saved_change_to_email?
     end
+  end
 
-    def test_should_raise_exception_if_not_permitted
-      @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      assert_raises ActiveModel::ForbiddenAttributesError do
-        @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true)
-      end
-    end
+  def test_should_assign_attributes
+    @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
+    @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true).permit(:login)
+    assert_equal 'modified', @user.login
+  end
 
-    def test_should_raise_exception_on_init_if_not_permitted
-      assert_raises ActiveModel::ForbiddenAttributesError do
-        @user = UserWithProtectedAttribute.new ActionController::Parameters.new(login: 'modified', is_admin: true)
-      end
-    end
-  else
-    def test_should_assign_attributes
-      @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      @user.attributes = { login: 'modified', is_admin: true }
-      assert_equal 'modified', @user.login
-    end
+  def test_should_not_assign_protected_attributes
+    @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
+    @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true).permit(:login)
+    assert !@user.is_admin?
+  end
 
-    def test_should_not_assign_protected_attributes
-      @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      @user.attributes = { login: 'modified', is_admin: true }
-      assert !@user.is_admin?
+  def test_should_raise_exception_if_not_permitted
+    @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
+    assert_raises ActiveModel::ForbiddenAttributesError do
+      @user.attributes = ActionController::Parameters.new(login: 'modified', is_admin: true)
     end
+  end
 
-    def test_should_assign_protected_attributes
-      @user = UserWithProtectedAttribute.new(login: 'login', is_admin: false)
-      if ::ActiveRecord::VERSION::STRING > "3.1"
-        @user.send(:assign_attributes, { login: 'modified', is_admin: true }, without_protection: true)
-      else
-        @user.send(:attributes=, { login: 'modified', is_admin: true }, false)
-      end
-      assert @user.is_admin?
+  def test_should_raise_exception_on_init_if_not_permitted
+    assert_raises ActiveModel::ForbiddenAttributesError do
+      @user = UserWithProtectedAttribute.new ActionController::Parameters.new(login: 'modified', is_admin: true)
     end
   end
 
@@ -291,11 +289,9 @@ class ActiveRecordTest < Minitest::Test
     assert_nil @person.encrypted_credentials_iv
   end
 
-  if ::ActiveRecord::VERSION::STRING > "3.1"
-    def test_should_allow_assign_attributes_with_nil
-      @person = Person.new
-      assert_nil(@person.assign_attributes nil)
-    end
+  def test_should_allow_assign_attributes_with_nil
+    @person = Person.new
+    assert_nil(@person.assign_attributes nil)
   end
 
   def test_that_alias_encrypts_column

--- a/test/run.sh
+++ b/test/run.sh
@@ -2,9 +2,9 @@
 
 set -e
 
-for RUBY in 2.5.9 2.6.10 2.7.6 3.0.4 3.1.2
+for RUBY in 2.6.10 2.7.6
 do
-  for ACTIVERECORD in 5.2.8 6.0.6 6.1.7
+  for ACTIVERECORD in 5.1.1 5.2.8
   do
     echo ">>> Testing with Ruby ${RUBY} and ActiveRecord ${ACTIVERECORD}."
     export RBENV_VERSION=$RUBY

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,12 +1,20 @@
-#!/usr/bin/env sh -e
+#!/usr/bin/env bash
 
-for RUBY in 1.9.3 2.0.0 2.1 2.2
+set -e
+
+for RUBY in 2.5.9 2.6.10 2.7.6 3.0.4 3.1.2
 do
-  for RAILS in 2.3.8 3.0.0 3.1.0 3.2.0 4.0.0 4.1.0 4.2.0
+  for ACTIVERECORD in 5.2.8 6.0.6 6.1.7
   do
-    if [[ $RUBY -gt 1.9.3 && $RAILS -lt 4.0.0 ]]; then
-      continue
-    fi
-    RBENV_VERSION=$RUBY ACTIVERECORD=$RAILS bundle && bundle exec rake
+    echo ">>> Testing with Ruby ${RUBY} and ActiveRecord ${ACTIVERECORD}."
+    export RBENV_VERSION=$RUBY
+    export ACTIVERECORD=$ACTIVERECORD
+
+    rbenv install $RUBY --skip-existing
+    bundle install
+    bundle check
+    bundle exec rake test
+    rm Gemfile.lock
+    echo ">>> Finished testing with Ruby ${RUBY} and ActiveRecord ${ACTIVERECORD}."
   done
 done

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pry'
 require 'simplecov'
 require 'simplecov-rcov'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,21 +2,17 @@
 
 require 'simplecov'
 require 'simplecov-rcov'
-require "codeclimate-test-reporter"
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [
     SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::RcovFormatter,
-    CodeClimate::TestReporter::Formatter
+    SimpleCov::Formatter::RcovFormatter
   ]
 )
 
 SimpleCov.start do
   add_filter 'test'
 end
-
-CodeClimate::TestReporter.start
 
 require 'minitest/autorun'
 


### PR DESCRIPTION
In an effort to make forward progress, and keep Travis credits from getting burned up too quickly, this modifies the configuration to:

- Stop testing EOL rubies
- Stop testing EOL ActiveRecord, except 5.1 and 5.2
- Remove checks for older removed ActiveRecord versions
- Include a fix for ActiveRecord 5.2, from fork source https://github.com/priyankatapar/attr_encrypted/commit/7e8702bd5418c927a39d8dd72c0adbea522d5663

With the above tests are now passing and this is ready for review so follow on work like adding Rails 7 support can continue.