### PR TITLE
[WIP] Configure CodeClimate per current standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_install:
 script:
   - bundle exec rake test
 after_script:
-  - ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.backend.json coverage/.resultset.json
+  - ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.json coverage/.resultset.json
   - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ env:
   - ACTIVERECORD=5.2.8
 jobs:
   fast_finish: true
-addons:
-  code_climate:
-    repo_token: a90435ed4954dd6e9f3697a20c5bc3754f67d94703f870e8fc7b00f69f5b2d06
+before_install:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+script:
+  - bundle exec rake test
+after_script:
+  - ./cc-test-reporter format-coverage -t simplecov -o coverage/codeclimate.backend.json coverage/.resultset.json
+  - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then ./cc-test-reporter upload-coverage; fi

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -47,7 +47,10 @@ Gem::Specification.new do |s|
   end
   s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('pry')
-  s.add_development_dependency('simplecov')
+
+  # CodeClimate doesn't work with higher version per:
+  # https://github.com/codeclimate/test-reporter/issues/413#issuecomment-580747855
+  s.add_development_dependency('simplecov', '~> 0.17')
   s.add_development_dependency('simplecov-rcov')
 
   s.cert_chain  = ['certs/saghaulor.pem']


### PR DESCRIPTION
Following the suggestions from CodeClimate on how to configure this https://github.com/codeclimate/test-reporter/blob/master/examples/ruby_examples.md#example-2

This will likely fail until we set `CC_TEST_REPORTER_ID` as an environment variable.