### PR TITLE
Restrict set_attribute_was patch to Rails versions >= 5.2, < 6

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -76,7 +76,7 @@ if defined?(ActiveRecord::Base)
               # attributes are handled, @attributes[attr].value is nil which
               # breaks attribute_was. Setting it here returns us to the expected
               # behavior.
-              if Gem::Requirement.new('~> 5.2').satisfied_by?(RAILS_VERSION)
+              if RAILS_VERSION < Gem::Version.new(6.0) && RAILS_VERSION >= Gem::Version.new(5.2)
                 # This is needed support attribute_was before a record has
                 # been saved
                 set_attribute_was(attr, __send__(attr)) if value != __send__(attr)

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -76,7 +76,7 @@ if defined?(ActiveRecord::Base)
               # attributes are handled, @attributes[attr].value is nil which
               # breaks attribute_was. Setting it here returns us to the expected
               # behavior.
-              if Gem::Requirement.new('>= 5.2').satisfied_by?(RAILS_VERSION)
+              if Gem::Requirement.new('~> 5.2').satisfied_by?(RAILS_VERSION)
                 # This is needed support attribute_was before a record has
                 # been saved
                 set_attribute_was(attr, __send__(attr)) if value != __send__(attr)


### PR DESCRIPTION
This fixes an issue where `set_attribute_was` can not be used in > Rails 6. We made this change on our fork to fix the issue: https://github.com/salsify/attr_encrypted/pull/1

I was running into issues with `Gem::Requirement.satisfied_by?()` with a frozen `Gem::Version`. I spent a bit of time trying to find a better solution, but this works. The pessimistic comparison, which we need here, is what was causing it. You can see the error in the previous test run.

Signed-off-by: Josh Branham <josh.php@gmail.com>