### PR TITLE
Restrict set_attribute_was patch to Rails versions >= 5.2, < 6 (Redux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,7 @@ env:
   - ACTIVERECORD=6.1.7
   - ACTIVERECORD=7.0.4
 jobs:
-  fast_finish: true
-  allow_failures:
-    - env: ACTIVERECORD=6.0.6
-    - env: ACTIVERECORD=6.1.7
-    - env: ACTIVERECORD=7.0.4
+  fast_finish: false
   exclude:
     - rvm: 2.6.10
       env: ACTIVERECORD=7.0.4

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -76,7 +76,7 @@ if defined?(ActiveRecord::Base)
               # attributes are handled, @attributes[attr].value is nil which
               # breaks attribute_was. Setting it here returns us to the expected
               # behavior.
-              if Gem::Requirement.new('~> 5.2').satisfied_by?(RAILS_VERSION)
+              if RAILS_VERSION < Gem::Version.new(6.0) && RAILS_VERSION >= Gem::Version.new(5.2)
                 # This is needed support attribute_was before a record has
                 # been saved
                 set_attribute_was(attr, __send__(attr)) if value != __send__(attr)

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -76,7 +76,7 @@ if defined?(ActiveRecord::Base)
               # attributes are handled, @attributes[attr].value is nil which
               # breaks attribute_was. Setting it here returns us to the expected
               # behavior.
-              if Gem::Requirement.new('>= 5.2').satisfied_by?(RAILS_VERSION)
+              if Gem::Requirement.new('~> 5.2').satisfied_by?(RAILS_VERSION)
                 # This is needed support attribute_was before a record has
                 # been saved
                 set_attribute_was(attr, __send__(attr)) if value != __send__(attr)


### PR DESCRIPTION
Reincarnation of @joshbranham's #427 because I pulled the trigger on merging too soon.