### PR TITLE
Plat 1435 make attr encrypted compat with rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-## Reverb Fork of attr_encrypted
-
-please see this ticket for additional context: https://reverb.atlassian.net/browse/PLAT-1435
+Please see this ticket for additional context on why this fork is neccessary: https://reverb.atlassian.net/browse/PLAT-1435
 
 # attr_encrypted
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Maintainer(s) wanted!!!
+## Reverb Fork of attr_encrypted
 
-**If you have an interest in maintaining this project... please see https://github.com/attr-encrypted/attr_encrypted/issues/379**
+please see this ticket for additional context: https://reverb.atlassian.net/browse/PLAT-1435
 
 # attr_encrypted
 

--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -76,7 +76,7 @@ if defined?(ActiveRecord::Base)
               # attributes are handled, @attributes[attr].value is nil which
               # breaks attribute_was. Setting it here returns us to the expected
               # behavior.
-              if Gem::Requirement.new('>= 5.2').satisfied_by?(RAILS_VERSION)
+              if RAILS_VERSION < Gem::Version.new(6.0) && RAILS_VERSION >= Gem::Version.new(5.2)
                 # This is needed support attribute_was before a record has
                 # been saved
                 set_attribute_was(attr, __send__(attr)) if value != __send__(attr)


### PR DESCRIPTION
Implements https://github.com/attr-encrypted/attr_encrypted/pull/431/files from parent repo which will allow this to be used with Rails 6.