### PR TITLE
Fix minitest guard for rails 4 breaking specs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,15 +16,10 @@ SimpleCov.start do
 end
 
 require 'minitest/autorun'
-
-# Rails 4.0.x pins to an old minitest
-unless defined?(MiniTest::Test)
-  MiniTest::Test = MiniTest::Unit::TestCase
-end
-
 require 'active_record'
 require 'digest/sha2'
 require 'sequel'
+
 if ActiveRecord.respond_to?(:deprecator)
   ActiveRecord.deprecator.behavior = :raise
 else


### PR DESCRIPTION
Fixes errors like the following, likely because minitest version is unbounded in the dev dependencies (which I think is fine). We don't need this guard for Rails 4, which we are not testing against anymore.

```
/Users/joshbranham/git/attr_encrypted/test/test_helper.rb:22:in `<top (required)>': uninitialized constant MiniTest (NameError)
```

I also need permission to turn off Travis @mvastola, I don't appear to be able to on that side of things.