### PR TITLE
Set required_ruby_version=2.7.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,5 +39,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        cache-version: 1
     - run: |
         bundle exec rake test

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.files      = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- test/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_dependency('encryptor', ['~> 3.0.0'])
   # support for testing with specific active record version

--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   activerecord_version = if ENV.key?('ACTIVERECORD')
     "~> #{ENV['ACTIVERECORD']}.0"
   else
-    '>= 2.0.0'
+    '>= 6.0.0'
   end
   s.add_development_dependency('activerecord', activerecord_version)
   s.add_development_dependency('actionpack', activerecord_version)
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   else
     s.add_development_dependency('sqlite3', '= 1.5.4')
   end
-  s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('pry')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('simplecov-rcov')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ SimpleCov.start do
 end
 
 require 'minitest/autorun'
+require 'active_support'
 require 'active_record'
 require 'digest/sha2'
 require 'sequel'


### PR DESCRIPTION
We no longer test or support 2.6.

Closes https://github.com/attr-encrypted/attr_encrypted/issues/460