### PR TITLE
Remove the unused dm-sqlite-adapter

### DIFF
--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   else
     s.add_development_dependency('sqlite3', '= 1.5.4')
   end
-  s.add_development_dependency('dm-sqlite-adapter')
   s.add_development_dependency('pry')
   s.add_development_dependency('simplecov')
   s.add_development_dependency('simplecov-rcov')


### PR DESCRIPTION
dm-sqlite-adapter is a SQLite adapter for DataMapper.

https://github.com/datamapper/dm-sqlite-adapter

Since support for DataMapper was dropped in version 4.1.0, this gem is no longer needed as a dependency.