### PR TITLE
Set required_ruby_version >= 2.7.0

### DIFF
--- a/attr_encrypted.gemspec
+++ b/attr_encrypted.gemspec
@@ -24,14 +24,14 @@ Gem::Specification.new do |s|
   s.files      = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- test/*`.split("\n")
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_dependency('encryptor', ['~> 3.0.0'])
   # support for testing with specific active record version
   activerecord_version = if ENV.key?('ACTIVERECORD')
     "~> #{ENV['ACTIVERECORD']}.0"
   else
-    '>= 2.0.0'
+    '>= 6.0.0'
   end
   s.add_development_dependency('activerecord', activerecord_version)
   s.add_development_dependency('actionpack', activerecord_version)


### PR DESCRIPTION
We no longer test or support 2.6.

Closes https://github.com/attr-encrypted/attr_encrypted/issues/460